### PR TITLE
Release 1.1.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "fr.luteal.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0.0"
+        versionCode = 2
+        versionName = "1.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/fastlane/metadata/android/en-US/changelogs/2.txt
+++ b/fastlane/metadata/android/en-US/changelogs/2.txt
@@ -1,0 +1,1 @@
+New: the current phase is clearly marked as recorded, estimated or indeterminate, with sourced daily guidance. Added private widgets for personal cycle and Duo information. Strengthened encrypted sync, Duo sharing and overall reliability.

--- a/fastlane/metadata/android/fr-FR/changelogs/2.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/2.txt
@@ -1,0 +1,1 @@
+Nouveau : phase actuelle clairement indiquée comme enregistrée, estimée ou indéterminée, avec des conseils quotidiens sourcés. Ajout de widgets privés pour le cycle personnel et Duo. Synchronisation chiffrée, partage Duo et fiabilité générale renforcés.


### PR DESCRIPTION
## Summary

- bump Android version code to 2 and version name to 1.1.0
- add French and English F-Droid changelogs for version code 2

## Verification

- `./gradlew testDebugUnitTest`
- `./gradlew lintDebug`
- `./gradlew assembleDebug`
- `./gradlew assembleRelease`
- verified the signed APK with APK Signature Scheme v2
- confirmed APK metadata reports version code 2 and version name 1.1.0
