### PR TITLE
chore: bump to 1.4.0 (7)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "fr.luteal.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 6
-        versionName = "1.3.0"
+        versionCode = 7
+        versionName = "1.4.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/fastlane/metadata/android/en-US/changelogs/7.txt
+++ b/fastlane/metadata/android/en-US/changelogs/7.txt
@@ -1,0 +1,5 @@
+- Condition-aware daily tips per tracking context and phase with deterministic selection.
+- Symptom-boosted guidance using the last 72 hours of observations.
+- Anxiety now offered when PMS or PMDD is declared.
+- Shared clinical sources deduped and partner tip mapping made exhaustive.
+- Em dashes removed and notification titles use consistent punctuation.

--- a/fastlane/metadata/android/fr-FR/changelogs/7.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/7.txt
@@ -1,0 +1,5 @@
+- Conseils quotidiens adaptés au contexte de suivi et à la phase, sélection déterministe.
+- Conseils renforcés par les symptômes des dernières 72 heures.
+- Anxiété proposée lorsque SPM ou TDPM est déclaré.
+- Sources cliniques partagées factorisées et mapping des conseils partenaire rendu exhaustif.
+- Tirets cadratins supprimés et titres de notifications harmonisés.


### PR DESCRIPTION
Bump versionName to 1.4.0 and versionCode to 7 for next release.

Changes in this release:
- Condition-aware daily tips per tracking context and phase with deterministic selection
- Symptom-boosted guidance using the last 72 hours of observations
- Anxiety offered when PMS or PMDD is declared
- Shared clinical sources deduped and partner tip mapping made exhaustive
- Em dashes removed and notification titles harmonized
- Preview file removed