### PR TITLE
fix: replace LocalDate.ofInstant with atZone to fix crash on Android 8-13 (closes #25)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "fr.luteal.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 7
-        versionName = "1.4.0"
+        versionCode = 8
+        versionName = "1.4.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/fr/luteal/app/LutealViewModel.kt
+++ b/app/src/main/java/fr/luteal/app/LutealViewModel.kt
@@ -60,7 +60,7 @@ class LutealViewModel @Inject constructor(
     private val operationState = MutableStateFlow(OperationState())
 
     /** Local calendar date at construction; seeds the StateFlow before the first emission. */
-    private val initialToday: LocalDate = LocalDate.ofInstant(clock.instant(), ZoneId.systemDefault())
+    private val initialToday: LocalDate = clock.instant().atZone(ZoneId.systemDefault()).toLocalDate()
 
     /**
      * Emits the local "today" now and after every date rollover, so a process
@@ -340,7 +340,7 @@ internal fun todayFlow(clock: Clock): Flow<LocalDate> = flow {
     val zone = ZoneId.systemDefault()
     while (true) {
         val now = clock.instant()
-        val today = LocalDate.ofInstant(now, zone)
+        val today = now.atZone(zone).toLocalDate()
         emit(today)
         val nextMidnight = today.plusDays(1).atStartOfDay(zone).toInstant()
         delay(Duration.between(now, nextMidnight).toMillis().coerceAtLeast(1_000L))

--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -1,0 +1,1 @@
+- Fix startup crash on Android 8 through 13.

--- a/fastlane/metadata/android/fr-FR/changelogs/8.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/8.txt
@@ -1,0 +1,1 @@
+- Correction du plantage au démarrage sur Android 8 à 13.

--- a/scripts/seed-release.sh
+++ b/scripts/seed-release.sh
@@ -91,7 +91,7 @@ cat >"${backup_file}" <<EOF
 {
   "schema_version": 1,
   "exported_at": "${timestamp}",
-  "app_version": "1.4.0-demo",
+  "app_version": "1.4.1-demo",
   "cycles": [
     {
       "id": "demo-cycle-1",


### PR DESCRIPTION
LocalDate.ofInstant was introduced in API 34 and throws NoSuchMethodError at startup on Android 8.0 to 13 (API 26-33). Replace it with Instant.atZone(zone).toLocalDate().

Bump version to 1.4.1 (8) and add changelogs.