### PR TITLE
ci: add lintDebug to build workflow and makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,5 +40,5 @@ jobs:
           cache-provider: "basic"
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
-      - name: Build and test
-        run: ./gradlew assembleDebug testDebugUnitTest
+      - name: Build, lint, and test
+        run: ./gradlew assembleDebug lintDebug testDebugUnitTest

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ADB          ?= adb
 DEVICE       ?=
 ANCHOR_DATE  ?= $(shell date -u +%F)
 
-.PHONY: help dev dev-install release-seed release-build release-check bump test clean
+.PHONY: help dev dev-install release-seed release-build release-check bump test lint clean
 
 help:
 	@echo "Luteal Build & Release Targets:"
@@ -28,6 +28,7 @@ help:
 	@echo "  make release-check   - Verify signature and Git metadata of $(RELEASE_APK)"
 	@echo "  make bump VERSION=1.x.y CODE=n - Update versionName and versionCode in build.gradle.kts"
 	@echo "  make test            - Run unit test suite"
+	@echo "  make lint            - Run Android Lint on debug variant"
 	@echo "  make clean           - Clean Gradle build outputs and $(DIST_DIR)/"
 
 # --- Development ---
@@ -50,6 +51,9 @@ test:
 	@echo "==> Running unit tests..."
 	./gradlew testDebugUnitTest
 
+lint:
+	@echo "==> Running Android Lint..."
+	./gradlew lintDebug
 # --- Release ---
 
 release-build:

--- a/app/src/main/java/fr/luteal/app/MainActivity.kt
+++ b/app/src/main/java/fr/luteal/app/MainActivity.kt
@@ -1,5 +1,6 @@
 package fr.luteal.app
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
@@ -74,6 +75,7 @@ class MainActivity : FragmentActivity() {
                 val barrierUp = lockState is AppLockState.Resolving || lockState is AppLockState.Locked
                 // PIN length comes from a Keystore read: produceState keeps
                 // that suspend call out of composition.
+                @SuppressLint("ProduceStateDoesNotAssignValue")
                 val expectedPinLength by produceState<Int?>(initialValue = null, lockState) {
                     value = appLockManager.pinLength()
                 }


### PR DESCRIPTION
### Summary
- Adds `lintDebug` to the CI workflow in `.github/workflows/build.yml` so that API level mismatches (such as `NewApi` violations against `minSdk = 26`) are caught before release.
- Adds `make lint` target to `Makefile`.
- Suppresses a Compose lint false-positive on `produceState` in `MainActivity.kt` with `@SuppressLint("ProduceStateDoesNotAssignValue")`.

### Verification
- `./gradlew lintDebug` passes with 0 errors.
- `./gradlew testDebugUnitTest` passes.