### PR TITLE
fix: audit remediation across security, clinical math, persistence, sync, and UI

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,9 +75,7 @@
             android:name=".widget.WidgetSystemEventReceiver"
             android:exported="false">
             <intent-filter>
-                <action android:name="android.intent.action.DATE_CHANGED" />
                 <action android:name="android.intent.action.TIMEZONE_CHANGED" />
-                <action android:name="android.intent.action.TIME_SET" />
                 <action android:name="android.intent.action.LOCALE_CHANGED" />
             </intent-filter>
         </receiver>

--- a/app/src/main/java/fr/luteal/app/AdbBackupImportActivity.kt
+++ b/app/src/main/java/fr/luteal/app/AdbBackupImportActivity.kt
@@ -6,6 +6,26 @@ import android.os.Bundle
 import android.util.Base64
 
 /**
+ * In-memory holder for pending backup payloads transferred between internal activities.
+ * Prevents unauthenticated external backup injection via public intent extras.
+ */
+object PendingBackupStore {
+    private var backupJson: String? = null
+
+    @Synchronized
+    fun set(json: String) {
+        backupJson = json
+    }
+
+    @Synchronized
+    fun consume(): String? {
+        val j = backupJson
+        backupJson = null
+        return j
+    }
+}
+
+/**
  * Forwards backup JSON from the adb shell to the normal in-app import flow.
  * The manifest protects this bridge with the platform DUMP permission.
  */
@@ -20,10 +40,10 @@ class AdbBackupImportActivity : Activity() {
                 }.getOrNull()
             }
         if (!backupJson.isNullOrBlank()) {
+            PendingBackupStore.set(backupJson)
             startActivity(
                 Intent(this, MainActivity::class.java).apply {
                     action = MainActivity.ACTION_IMPORT_BACKUP
-                    putExtra(MainActivity.EXTRA_IMPORT_JSON, backupJson)
                     addFlags(
                         Intent.FLAG_ACTIVITY_CLEAR_TOP or
                             Intent.FLAG_ACTIVITY_SINGLE_TOP or

--- a/app/src/main/java/fr/luteal/app/LutealViewModel.kt
+++ b/app/src/main/java/fr/luteal/app/LutealViewModel.kt
@@ -168,26 +168,7 @@ class LutealViewModel @Inject constructor(
         viewModelScope.launch {
             operationState.update { it.copy(failed = false) }
             runCatching {
-                val existing = uiState.value.cycles
-                require(existing.none { it.startDate == startDate }) {
-                    "Un cycle existe déjà à cette date."
-                }
-                val prevCycle = existing
-                    .filter { it.startDate < startDate }
-                    .maxByOrNull { it.startDate }
-                if (prevCycle != null && (prevCycle.endDate == null || prevCycle.endDate >= startDate)) {
-                    cycleRepository.saveCycle(prevCycle.copy(endDate = startDate.minusDays(1)))
-                }
-                val nextStart = existing
-                    .map(Cycle::startDate)
-                    .filter { it > startDate }
-                    .minOrNull()
-                val cycle = Cycle(
-                    id = UUID.randomUUID().toString(),
-                    startDate = startDate,
-                    endDate = nextStart?.minusDays(1)
-                )
-                cycleRepository.saveCycle(cycle)
+                cycleRepository.addBackfilledCycle(startDate)
                 notificationScheduler.reconcileAllSchedules()
             }.onFailure {
                 operationState.update { it.copy(failed = true) }
@@ -199,26 +180,7 @@ class LutealViewModel @Inject constructor(
         viewModelScope.launch {
             operationState.update { it.copy(failed = false) }
             runCatching {
-                val existing = uiState.value.cycles
-                val targetCycle = existing.firstOrNull { it.id == cycleId }
-                    ?: error("Cycle introuvable.")
-                if (targetCycle.startDate == newStartDate) return@launch
-
-                require(existing.none { it.id != cycleId && it.startDate == newStartDate }) {
-                    "Un autre cycle commence déjà à cette date."
-                }
-
-                val updatedList = existing.map {
-                    if (it.id == cycleId) it.copy(startDate = newStartDate) else it
-                }.sortedBy { it.startDate }
-
-                for (i in updatedList.indices) {
-                    val current = updatedList[i]
-                    val nextStart = updatedList.getOrNull(i + 1)?.startDate
-                    val newEndDate = nextStart?.minusDays(1)
-                    val reconciled = current.copy(endDate = newEndDate)
-                    cycleRepository.saveCycle(reconciled)
-                }
+                cycleRepository.editCycleStartDate(cycleId, newStartDate)
                 notificationScheduler.reconcileAllSchedules()
             }.onFailure {
                 operationState.update { it.copy(failed = true) }
@@ -230,19 +192,7 @@ class LutealViewModel @Inject constructor(
         viewModelScope.launch {
             operationState.update { it.copy(failed = false) }
             runCatching {
-                cycleRepository.deleteCycle(cycleId)
-                val remaining = uiState.value.cycles
-                    .filter { it.id != cycleId }
-                    .sortedBy { it.startDate }
-
-                for (i in remaining.indices) {
-                    val current = remaining[i]
-                    val nextStart = remaining.getOrNull(i + 1)?.startDate
-                    val newEndDate = nextStart?.minusDays(1)
-                    if (current.endDate != newEndDate) {
-                        cycleRepository.saveCycle(current.copy(endDate = newEndDate))
-                    }
-                }
+                cycleRepository.deleteCycleAndReconcile(cycleId)
                 notificationScheduler.reconcileAllSchedules()
             }.onFailure {
                 operationState.update { it.copy(failed = true) }

--- a/app/src/main/java/fr/luteal/app/LutealViewModel.kt
+++ b/app/src/main/java/fr/luteal/app/LutealViewModel.kt
@@ -44,6 +44,7 @@ import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import javax.inject.Inject
 
@@ -82,6 +83,22 @@ class LutealViewModel @Inject constructor(
         operationState,
         todayFlow
     ) { records, operation, today ->
+        val todayEntry = records.entries.firstOrNull { it.date == today }
+        val dayOfCycle = records.currentCycle?.takeIf { !today.isBefore(it.startDate) }?.let {
+            ChronoUnit.DAYS.between(it.startDate, today).toInt() + 1
+        }
+        val estimateResult = CycleEstimateCalculator.evaluate(
+            cycles = records.cycles,
+            ageBand = AgeBand.fromId(records.preferences.ageBand),
+            hasTimingContext = records.preferences.hasTimingContext
+        )
+        val estimate = (estimateResult as? CycleEstimateResult.Available)?.estimate
+        val currentPhase = CurrentCyclePhaseCalculator.evaluate(
+            today = today,
+            currentCycle = records.currentCycle,
+            todayEntry = todayEntry,
+            estimateResult = estimateResult
+        )
         LutealUiState(
             today = today,
             cycles = records.cycles,
@@ -89,18 +106,19 @@ class LutealViewModel @Inject constructor(
             entries = records.entries,
             biomarkers = records.biomarkers,
             preferences = records.preferences,
-            estimateResult = CycleEstimateCalculator.evaluate(
-                cycles = records.cycles,
-                ageBand = AgeBand.fromId(records.preferences.ageBand),
-                hasTimingContext = records.preferences.hasTimingContext
-            ),
+            estimateResult = estimateResult,
             entrySaveState = operation.entrySaveState,
-            operationFailed = operation.failed
+            operationFailed = operation.failed,
+            isInitializing = false,
+            todayEntry = todayEntry,
+            dayOfCycle = dayOfCycle,
+            estimate = estimate,
+            currentPhase = currentPhase
         )
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
-        initialValue = LutealUiState(today = initialToday)
+        initialValue = LutealUiState(today = initialToday, isInitializing = true)
     )
 
     fun saveEntry(entry: DailyEntry, biomarker: BiomarkerObservation, startsNewCycle: Boolean) {
@@ -246,27 +264,20 @@ data class LutealUiState(
     val preferences: UserPreferences = UserPreferences(),
     val estimateResult: CycleEstimateResult = CycleEstimateResult.NeedsMoreHistory,
     val entrySaveState: EntrySaveState = EntrySaveState.IDLE,
-    val operationFailed: Boolean = false
-) {
-    val estimate: CycleEstimate?
-        get() = (estimateResult as? CycleEstimateResult.Available)?.estimate
-
-    val todayEntry: DailyEntry?
-        get() = entries.firstOrNull { it.date == today }
-
-    val dayOfCycle: Int?
-        get() = currentCycle
-            ?.takeIf { !today.isBefore(it.startDate) }
-            ?.let { java.time.temporal.ChronoUnit.DAYS.between(it.startDate, today).toInt() + 1 }
-
-    val currentPhase: CurrentCyclePhase
-        get() = CurrentCyclePhaseCalculator.evaluate(
-            today = today,
-            currentCycle = currentCycle,
-            todayEntry = todayEntry,
-            estimateResult = estimateResult
-        )
-}
+    val operationFailed: Boolean = false,
+    val isInitializing: Boolean = false,
+    val todayEntry: DailyEntry? = entries.firstOrNull { it.date == today },
+    val dayOfCycle: Int? = currentCycle
+        ?.takeIf { !today.isBefore(it.startDate) }
+        ?.let { ChronoUnit.DAYS.between(it.startDate, today).toInt() + 1 },
+    val estimate: CycleEstimate? = (estimateResult as? CycleEstimateResult.Available)?.estimate,
+    val currentPhase: CurrentCyclePhase = CurrentCyclePhaseCalculator.evaluate(
+        today = today,
+        currentCycle = currentCycle,
+        todayEntry = todayEntry,
+        estimateResult = estimateResult
+    )
+)
 
 enum class EntrySaveState {
     IDLE,

--- a/app/src/main/java/fr/luteal/app/MainActivity.kt
+++ b/app/src/main/java/fr/luteal/app/MainActivity.kt
@@ -42,13 +42,12 @@ class MainActivity : FragmentActivity() {
     lateinit var userPreferencesDataStore: UserPreferencesDataStore
 
     private var widgetDestination by mutableStateOf<String?>(null)
-    private var pendingImportJson by mutableStateOf<String?>(null)
+    private var bufferedImportJson by mutableStateOf<String?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         widgetDestination = intent.widgetDestination()
-        pendingImportJson = intent.importBackupJson()
-        intent.removeExtra(EXTRA_IMPORT_JSON)
+        handleBackupImport(intent)
         enableEdgeToEdge()
 
         lifecycle.addObserver(appLockManager)
@@ -90,8 +89,8 @@ class MainActivity : FragmentActivity() {
                         LutealMainScaffold(
                             widgetDestination = widgetDestination,
                             onWidgetDestinationConsumed = { widgetDestination = null },
-                            pendingImportJson = pendingImportJson,
-                            onPendingImportConsumed = { pendingImportJson = null }
+                            pendingImportJson = if (!barrierUp) bufferedImportJson else null,
+                            onPendingImportConsumed = { bufferedImportJson = null }
                         )
                     }
                     if (lockState is AppLockState.Resolving) {
@@ -116,8 +115,7 @@ class MainActivity : FragmentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         widgetDestination = intent.widgetDestination()
-        pendingImportJson = intent.importBackupJson()
-        intent.removeExtra(EXTRA_IMPORT_JSON)
+        handleBackupImport(intent)
     }
 
     private fun showBiometricPrompt() {
@@ -143,10 +141,12 @@ class MainActivity : FragmentActivity() {
         takeIf { action == ACTION_OPEN_WIDGET_DESTINATION }
             ?.getStringExtra(EXTRA_WIDGET_DESTINATION)
 
-    private fun Intent.importBackupJson(): String? =
-        takeIf { action == ACTION_IMPORT_BACKUP }
-            ?.getStringExtra(EXTRA_IMPORT_JSON)
-
+    private fun handleBackupImport(intent: Intent) {
+        if (intent.action == ACTION_IMPORT_BACKUP && !intent.hasExtra(EXTRA_IMPORT_JSON)) {
+            bufferedImportJson = PendingBackupStore.consume()
+        }
+        intent.removeExtra(EXTRA_IMPORT_JSON)
+    }
     companion object {
         const val ACTION_OPEN_WIDGET_DESTINATION = "fr.luteal.app.action.OPEN_WIDGET_DESTINATION"
         const val ACTION_IMPORT_BACKUP = "fr.luteal.app.action.IMPORT_BACKUP"

--- a/app/src/main/java/fr/luteal/app/navigation/DuoScreen.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/DuoScreen.kt
@@ -1,5 +1,8 @@
 package fr.luteal.app.navigation
 
+import android.content.Context
+import android.os.Build
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -37,12 +40,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.text.AnnotatedString
 import androidx.hilt.navigation.compose.hiltViewModel
 import fr.luteal.app.R
 import fr.luteal.core.common.LocalizedDateFormatter
@@ -287,8 +289,8 @@ private fun InvitationPendingSection(
     pairingCode: String?,
     onCancel: () -> Unit
 ) {
+    val context = LocalContext.current
     var copied by remember { mutableStateOf(false) }
-    val clipboard = LocalClipboardManager.current
 
     LutealCard(modifier = Modifier.fillMaxWidth()) {
         Column(verticalArrangement = Arrangement.spacedBy(LutealSpacing.sm)) {
@@ -320,7 +322,20 @@ private fun InvitationPendingSection(
                         if (copied) R.string.duo_code_copied else R.string.duo_code_copy
                     ),
                     onClick = {
-                        clipboard.setText(AnnotatedString(code))
+                        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? android.content.ClipboardManager
+                        if (clipboard != null) {
+                            val clip = android.content.ClipData.newPlainText(
+                                context.getString(R.string.duo_code_label),
+                                code
+                            ).apply {
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                    description.extras = android.os.PersistableBundle().apply {
+                                        putBoolean(android.content.ClipDescription.EXTRA_IS_SENSITIVE, true)
+                                    }
+                                }
+                            }
+                            clipboard.setPrimaryClip(clip)
+                        }
                         copied = true
                     },
                     modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/fr/luteal/app/navigation/DuoScreen.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/DuoScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Favorite
@@ -45,6 +46,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.Role
 import androidx.hilt.navigation.compose.hiltViewModel
 import fr.luteal.app.R
 import fr.luteal.core.common.LocalizedDateFormatter
@@ -512,7 +514,13 @@ private fun GrantToggle(
     val description = stringResource(descRes)
 
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .toggleable(
+                value = checked,
+                role = Role.Switch,
+                onValueChange = { onToggleGrant(field, it) }
+            ),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -531,7 +539,7 @@ private fun GrantToggle(
         }
         Switch(
             checked = checked,
-            onCheckedChange = { onToggleGrant(field, it) }
+            onCheckedChange = null
         )
     }
 }
@@ -839,8 +847,8 @@ private fun nudgeText(name: String): String = stringResource(
 )
 
 @Composable
-private fun partnerTipTitle(id: String): String = stringResource(
-    when (id) {
+private fun partnerTipTitle(id: String): String {
+    val resId = when (id) {
         "partner_menstrual_comfort" -> R.string.partner_tip_partner_menstrual_comfort
         "partner_menstrual_space" -> R.string.partner_tip_partner_menstrual_space
         "partner_menstrual_listen" -> R.string.partner_tip_partner_menstrual_listen
@@ -855,13 +863,14 @@ private fun partnerTipTitle(id: String): String = stringResource(
         "partner_luteal_practical" -> R.string.partner_tip_partner_luteal_practical
         "partner_luteal_pmdd_space" -> R.string.partner_tip_partner_luteal_pmdd_space
         "partner_perimeno_support" -> R.string.partner_tip_partner_perimeno_support
-        else -> error("Unknown partner tip id: $id")
+        else -> null
     }
-)
+    return if (resId != null) stringResource(resId) else ""
+}
 
 @Composable
-private fun partnerTipMessage(id: String): String = stringResource(
-    when (id) {
+private fun partnerTipMessage(id: String): String {
+    val resId = when (id) {
         "partner_menstrual_comfort" -> R.string.partner_tip_partner_menstrual_comfort_message
         "partner_menstrual_space" -> R.string.partner_tip_partner_menstrual_space_message
         "partner_menstrual_listen" -> R.string.partner_tip_partner_menstrual_listen_message
@@ -876,6 +885,7 @@ private fun partnerTipMessage(id: String): String = stringResource(
         "partner_luteal_practical" -> R.string.partner_tip_partner_luteal_practical_message
         "partner_luteal_pmdd_space" -> R.string.partner_tip_partner_luteal_pmdd_space_message
         "partner_perimeno_support" -> R.string.partner_tip_partner_perimeno_support_message
-        else -> error("Unknown partner tip id: $id")
+        else -> null
     }
-)
+    return if (resId != null) stringResource(resId) else ""
+}

--- a/app/src/main/java/fr/luteal/app/navigation/DuoViewModel.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/DuoViewModel.kt
@@ -110,11 +110,12 @@ class DuoViewModel @Inject constructor(
                 }
                 .onFailure { err ->
                     val missingLink = err is fr.luteal.core.network.FolicularApiException && err.status == 404
-                    val cached = widgetCacheRepository.getLatest()
-                    if (missingLink && cached == null) {
-                        _uiState.update { it.copy(isLoading = false) }
+                    if (missingLink) {
+                        widgetCacheRepository.clear()
+                        _uiState.update { DuoUiState(phase = DuoPhase.NoLink, isLoading = false) }
                         discoverLinks()
                     } else {
+                        val cached = widgetCacheRepository.getLatest()
                         applyCachedProjection()
                         _uiState.update { it.copy(isLoading = false, error = if (cached != null) null else err.message) }
                     }
@@ -328,6 +329,7 @@ class DuoViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true, error = null) }
             runCatching { duoRepository.revokeLink(linkId) }
                 .onSuccess {
+                    duoKeyStore.remove(linkId)
                     widgetCacheRepository.clear()
                     _uiState.update {
                         DuoUiState(phase = DuoPhase.NoLink)

--- a/app/src/main/java/fr/luteal/app/navigation/JournalScreen.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/JournalScreen.kt
@@ -586,10 +586,10 @@ private fun SelectedDayInspectionCard(
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.onPrimaryContainer
                         )
-                        Row(horizontalArrangement = Arrangement.spacedBy(LutealSpacing.xs)) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(LutealSpacing.sm)) {
                             IconButton(
                                 onClick = { onEditCycle(cycleStart) },
-                                modifier = Modifier.size(36.dp)
+                                modifier = Modifier.size(48.dp)
                             ) {
                                 Icon(
                                     imageVector = Icons.Rounded.Edit,
@@ -599,7 +599,7 @@ private fun SelectedDayInspectionCard(
                             }
                             IconButton(
                                 onClick = { onDeleteCycle(cycleStart) },
-                                modifier = Modifier.size(36.dp)
+                                modifier = Modifier.size(48.dp)
                             ) {
                                 Icon(
                                     imageVector = Icons.Rounded.Delete,
@@ -701,10 +701,10 @@ private fun JournalEntryRow(
                         modifier = Modifier.padding(horizontal = LutealSpacing.xs, vertical = 2.dp)
                     )
                 }
-                Row(horizontalArrangement = Arrangement.spacedBy(LutealSpacing.xxs)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(LutealSpacing.sm)) {
                     IconButton(
                         onClick = { onEditCycle(cycleStart) },
-                        modifier = Modifier.size(32.dp)
+                        modifier = Modifier.size(48.dp)
                     ) {
                         Icon(
                             imageVector = Icons.Rounded.Edit,
@@ -715,7 +715,7 @@ private fun JournalEntryRow(
                     }
                     IconButton(
                         onClick = { onDeleteCycle(cycleStart) },
-                        modifier = Modifier.size(32.dp)
+                        modifier = Modifier.size(48.dp)
                     ) {
                         Icon(
                             imageVector = Icons.Rounded.Delete,

--- a/app/src/main/java/fr/luteal/app/navigation/LutealMainScaffold.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/LutealMainScaffold.kt
@@ -22,7 +22,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -52,7 +52,7 @@ fun LutealMainScaffold(
     onPendingImportConsumed: () -> Unit = {},
     viewModel: LutealViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var selectedDestination by rememberSaveable { mutableStateOf(LutealDestination.TODAY) }
     var editorRequest by remember { mutableStateOf<EditorRequest?>(null) }
     var showBackfillDialog by remember { mutableStateOf(false) }
@@ -109,7 +109,9 @@ fun LutealMainScaffold(
         }
     }
 
-    if (!uiState.preferences.hasCompletedOnboarding) {
+    if (uiState.isInitializing) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) { }
+    } else if (!uiState.preferences.hasCompletedOnboarding) {
         OnboardingScreen(
             onComplete = { role, focusMap, ageBandId ->
                 viewModel.completeOnboarding(role, focusMap, ageBandId)

--- a/app/src/main/java/fr/luteal/app/navigation/SettingsScreen.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/SettingsScreen.kt
@@ -285,7 +285,8 @@ fun SettingsScreen(
             getAccountCode = viewModel::getAccountCode,
             onRecoveryCodeChange = viewModel::onRecoveryCodeChange,
             onRecoverAccount = viewModel::recoverAccount,
-            onDismissRecoveryMessage = viewModel::clearRecoveryState
+            onDismissRecoveryMessage = viewModel::clearRecoveryState,
+            onUnlinkSync = viewModel::unlinkSync
         )
         if (BuildConfig.DEBUG) {
             TestDataCard(
@@ -1485,7 +1486,8 @@ private fun SyncCard(
     getAccountCode: () -> String?,
     onRecoveryCodeChange: (String) -> Unit,
     onRecoverAccount: () -> Unit,
-    onDismissRecoveryMessage: () -> Unit
+    onDismissRecoveryMessage: () -> Unit,
+    onUnlinkSync: () -> Unit
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(LutealSpacing.xs)) {
         SettingsSectionHeader(title = stringResource(R.string.settings_sync_title))
@@ -1559,6 +1561,14 @@ private fun SyncCard(
                 HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
                 AccountCodeSection(state = state, getAccountCode = getAccountCode)
+
+                if (state.isLinked || state.hasAccount) {
+                    LutealSecondaryButton(
+                        text = stringResource(R.string.settings_sync_unlink),
+                        onClick = onUnlinkSync,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
 
                 if (!state.hasAccount) {
                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)

--- a/app/src/main/java/fr/luteal/app/navigation/SettingsScreen.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/SettingsScreen.kt
@@ -53,10 +53,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -1581,7 +1579,7 @@ private fun AccountCodeSection(state: SettingsSyncUiState, getAccountCode: () ->
     val accountCode = remember(state.hasAccount, state.lastSyncedEpochMillis) {
         getAccountCode()
     }
-    val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
     var copied by remember { mutableStateOf(false) }
 
     Column(verticalArrangement = Arrangement.spacedBy(LutealSpacing.xs)) {
@@ -1611,7 +1609,20 @@ private fun AccountCodeSection(state: SettingsSyncUiState, getAccountCode: () ->
                 text = if (copied) stringResource(R.string.settings_sync_account_code_copied)
                 else stringResource(R.string.settings_sync_account_code_copy),
                 onClick = {
-                    clipboardManager.setText(AnnotatedString(accountCode))
+                    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? android.content.ClipboardManager
+                    if (clipboard != null) {
+                        val clip = android.content.ClipData.newPlainText(
+                            context.getString(R.string.settings_sync_account_code_title),
+                            accountCode
+                        ).apply {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                description.extras = android.os.PersistableBundle().apply {
+                                    putBoolean(android.content.ClipDescription.EXTRA_IS_SENSITIVE, true)
+                                }
+                            }
+                        }
+                        clipboard.setPrimaryClip(clip)
+                    }
                     copied = true
                 },
                 modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/fr/luteal/app/navigation/SettingsViewModel.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/SettingsViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -77,6 +78,17 @@ class SettingsViewModel @Inject constructor(
     private val clinicalReportAggregator: ClinicalReportAggregator,
     private val notificationScheduler: NotificationScheduler
 ) : ViewModel() {
+    private val syncCursorStore: SyncCursorStore get() = cursorStore
+
+    private val _syncUiState = MutableStateFlow(
+        SettingsSyncUiState(
+            hasAccount = credentialStore.load() != null,
+            isLinked = credentialStore.load() != null,
+            accountCode = credentialStore.load()?.accountCode,
+            deviceToken = credentialStore.load()?.deviceToken
+        )
+    )
+    val syncUiState: StateFlow<SettingsSyncUiState> = _syncUiState.asStateFlow()
 
     /** Local edit buffer for the base URL field, kept out of the DataStore. */
     private val baseUrlDraft = MutableStateFlow("")
@@ -99,8 +111,8 @@ class SettingsViewModel @Inject constructor(
         }
 
     private val drafts: Flow<Drafts> =
-        combine(baseUrlDraft, recoveryCodeDraft, fileOps) { base, recovery, files ->
-            Drafts(base, recovery, files.export, files.wipe, files.importOp, files.report)
+        combine(baseUrlDraft, recoveryCodeDraft, fileOps, _syncUiState) { base, recovery, files, syncUi ->
+            Drafts(base, recovery, files.export, files.wipe, files.importOp, files.report, syncUi)
         }
     val uiState: StateFlow<SettingsSyncUiState> = combine(
         userRepository.getUserPreferences(),
@@ -109,6 +121,8 @@ class SettingsViewModel @Inject constructor(
         testDataActionState,
         recoveryState
     ) { preferences, syncPreferences, draft, actionState, recovery ->
+        val creds = credentialStore.load()
+        val isLinked = creds != null
         SettingsSyncUiState(
             onlineSyncEnabled = preferences.syncMode == SyncMode.ONLINE_CLOUD.name,
             baseUrlDraft = draft.baseUrl,
@@ -123,7 +137,10 @@ class SettingsViewModel @Inject constructor(
             wipeState = draft.wipeState,
             importState = draft.importState,
             reportExportState = draft.reportExportState,
-            hasAccount = credentialStore.load() != null,
+            hasAccount = isLinked,
+            isLinked = isLinked,
+            accountCode = creds?.accountCode,
+            deviceToken = creds?.deviceToken,
             declaredContexts = preferences.declaredContexts,
             ageBand = AgeBand.fromId(preferences.ageBand),
             isAppLockEnabled = preferences.isAppLockEnabled,
@@ -230,10 +247,22 @@ class SettingsViewModel @Inject constructor(
 
     fun getAccountCode(): String? = credentialStore.load()?.accountCode
 
+    fun unlinkSync() {
+        viewModelScope.launch {
+            credentialStore.clear()
+            syncCursorStore.clear()
+            _syncUiState.update { it.copy(isLinked = false, accountCode = null, deviceToken = null) }
+        }
+    }
+
     // --- Account recovery ---------------------------------------------------
 
     fun onRecoveryCodeChange(value: String) {
         recoveryCodeDraft.value = value
+    }
+
+    fun recoverAccount() {
+        recoverAccount(recoveryCodeDraft.value)
     }
 
     /**
@@ -244,18 +273,15 @@ class SettingsViewModel @Inject constructor(
      * could substitute for it. On success the credentials are stored and the
      * next sync pulls and decrypts the account's history.
      */
-    fun recoverAccount() {
-        val code = recoveryCodeDraft.value.trim()
+    fun recoverAccount(accountCode: String) {
+        val code = accountCode.trim()
         if (code.isBlank()) return
-        if (credentialStore.load() != null) {
-            recoveryState.value = RecoveryState.Error(messageResId = R.string.settings_recovery_error_already_linked)
-            return
-        }
         viewModelScope.launch {
             recoveryState.value = RecoveryState.Loading
             runCatching {
                 val client = apiClientFactory.create(cursorStore.getBaseUrl())
                 val result = client.addDevice(code, cursorStore.getDeviceLabel())
+                credentialStore.clear()
                 credentialStore.save(
                     SyncCredentials(
                         accountId = result.accountId,
@@ -266,9 +292,17 @@ class SettingsViewModel @Inject constructor(
                 // A restored device starts from cursor zero so it pulls the
                 // whole history rather than resuming someone else's position.
                 syncDataStore.setCursor(0L)
-            }.onSuccess {
+                result
+            }.onSuccess { result ->
                 recoveryState.value = RecoveryState.Success
                 recoveryCodeDraft.value = ""
+                _syncUiState.update {
+                    it.copy(
+                        isLinked = true,
+                        accountCode = code,
+                        deviceToken = result.deviceToken
+                    )
+                }
                 syncScheduler.syncNow()
             }.onFailure { err ->
                 recoveryState.value = RecoveryState.Error(
@@ -599,6 +633,9 @@ data class SettingsSyncUiState(
     val importState: DataImportState = DataImportState.Idle,
     val reportExportState: DataExportState = DataExportState.Idle,
     val hasAccount: Boolean = false,
+    val isLinked: Boolean = false,
+    val accountCode: String? = null,
+    val deviceToken: String? = null,
     /** Contexts the user has declared, editable after onboarding. */
     val declaredContexts: Set<TrackingContext> = emptySet(),
     /** Null means no band declared, which is a valid state. */
@@ -636,7 +673,8 @@ private data class Drafts(
     val exportState: DataExportState,
     val wipeState: DataWipeState,
     val importState: DataImportState,
-    val reportExportState: DataExportState
+    val reportExportState: DataExportState,
+    val syncUi: SettingsSyncUiState = SettingsSyncUiState()
 )
 
 sealed interface TestDataActionState {

--- a/app/src/main/java/fr/luteal/core/data/ClinicalReportAggregator.kt
+++ b/app/src/main/java/fr/luteal/core/data/ClinicalReportAggregator.kt
@@ -8,6 +8,7 @@ import fr.luteal.core.model.ClinicalReportConfig
 import fr.luteal.core.model.ClinicalReportData
 import fr.luteal.core.model.Cycle
 import fr.luteal.core.model.CycleExclusionReason
+import fr.luteal.core.model.CycleEstimateCalculator
 import fr.luteal.core.model.CycleReportRow
 import fr.luteal.core.model.CycleStatistics
 import fr.luteal.core.model.DailyEntry
@@ -180,6 +181,7 @@ class ClinicalReportAggregator @Inject constructor(
                 val cycle = selectedCycles[i]
                 val nextStart = if (i < selectedCycles.size - 1) selectedCycles[i + 1].startDate else null
                 val isCompleted = cycle.endDate != null || nextStart != null
+                val effectiveEnd = cycle.endDate ?: nextStart?.minusDays(1)
                 val length = if (nextStart != null) {
                     ChronoUnit.DAYS.between(cycle.startDate, nextStart).toInt()
                 } else if (cycle.endDate != null) {
@@ -189,7 +191,7 @@ class ClinicalReportAggregator @Inject constructor(
                 }
 
                 val cycleEntries = selectedEntries.filter { entry ->
-                    entry.date >= cycle.startDate && (cycle.endDate == null || entry.date <= cycle.endDate)
+                    entry.date >= cycle.startDate && (effectiveEnd == null || entry.date <= effectiveEnd)
                 }
 
                 val bleedingDaysCount = cycleEntries.count {
@@ -205,7 +207,7 @@ class ClinicalReportAggregator @Inject constructor(
                     CycleReportRow(
                         cycleId = cycle.id,
                         startDate = cycle.startDate,
-                        endDate = cycle.endDate ?: nextStart?.minusDays(1),
+                        endDate = effectiveEnd,
                         lengthDays = length,
                         bleedingDaysCount = bleedingDaysCount,
                         peakFlow = peakFlow,
@@ -215,8 +217,10 @@ class ClinicalReportAggregator @Inject constructor(
                     )
                 )
 
-                if (isCompleted) {
+                if (isCompleted && !cycle.isExcludedFromEstimates && length in CycleEstimateCalculator.plausibleCycleDays) {
                     completedLengths.add(length)
+                }
+                if (isCompleted) {
                     bleedingDaysList.add(bleedingDaysCount)
                 }
             }
@@ -241,10 +245,9 @@ class ClinicalReportAggregator @Inject constructor(
             val maxLength = completedLengths.maxOrNull()
             val meanBleeding = if (bleedingDaysList.isNotEmpty()) bleedingDaysList.average() else null
 
-            val shortestCycle = selectedCycles.filter { it.endDate != null }
-                .minByOrNull { ChronoUnit.DAYS.between(it.startDate, it.endDate).toInt() + 1 }
-            val longestCycle = selectedCycles.filter { it.endDate != null }
-                .maxByOrNull { ChronoUnit.DAYS.between(it.startDate, it.endDate).toInt() + 1 }
+            val validCompletedCycles = cycleRows.filter { !it.isExcluded && it.lengthDays in CycleEstimateCalculator.plausibleCycleDays }
+            val shortestCycle = validCompletedCycles.minByOrNull { it.lengthDays }
+            val longestCycle = validCompletedCycles.maxByOrNull { it.lengthDays }
 
             val cycleStats = CycleStatistics(
                 totalCyclesCount = selectedCycles.size,

--- a/app/src/main/java/fr/luteal/core/data/DataImportManager.kt
+++ b/app/src/main/java/fr/luteal/core/data/DataImportManager.kt
@@ -221,24 +221,34 @@ class DataImportManager @Inject constructor(
                             val existing = dailyEntryDao.getEntryOnce(entryDto.date)
                             if (existing == null || updatedAtMillis >= existing.updatedAtEpochMillis) {
                                 dailyEntryDao.upsert(entity)
+                                syncStateDao.upsert(
+                                    SyncStateEntity(
+                                        entityType = SyncStateEntity.TYPE_DAILY_ENTRY,
+                                        entityId = entity.date,
+                                        clientRev = UUID.randomUUID().toString(),
+                                        createdAtEpochMillis = updatedAtMillis,
+                                        updatedAtEpochMillis = now,
+                                        dirty = true,
+                                        lastPushError = null
+                                    )
+                                )
                                 entriesCount++
                             }
                         } else {
                             dailyEntryDao.upsert(entity)
+                            syncStateDao.upsert(
+                                SyncStateEntity(
+                                    entityType = SyncStateEntity.TYPE_DAILY_ENTRY,
+                                    entityId = entity.date,
+                                    clientRev = UUID.randomUUID().toString(),
+                                    createdAtEpochMillis = updatedAtMillis,
+                                    updatedAtEpochMillis = now,
+                                    dirty = true,
+                                    lastPushError = null
+                                )
+                            )
                             entriesCount++
                         }
-
-                        syncStateDao.upsert(
-                            SyncStateEntity(
-                                entityType = SyncStateEntity.TYPE_DAILY_ENTRY,
-                                entityId = entity.date,
-                                clientRev = UUID.randomUUID().toString(),
-                                createdAtEpochMillis = updatedAtMillis,
-                                updatedAtEpochMillis = now,
-                                dirty = true,
-                                lastPushError = null
-                            )
-                        )
                     }
 
                     // Restore Symptom Logs
@@ -307,23 +317,34 @@ class DataImportManager @Inject constructor(
                             val existing = biomarkerDao.getObservationOnce(biomarkerDto.date)
                             if (existing == null || updatedAtMillis >= existing.updatedAtEpochMillis) {
                                 biomarkerDao.upsert(entity)
+                                syncStateDao.upsert(
+                                    SyncStateEntity(
+                                        entityType = SyncStateEntity.TYPE_BIOMARKER_OBSERVATION,
+                                        entityId = SyncStateEntity.biomarkerEntityId(entity.date),
+                                        clientRev = UUID.randomUUID().toString(),
+                                        createdAtEpochMillis = updatedAtMillis,
+                                        updatedAtEpochMillis = now,
+                                        dirty = true,
+                                        lastPushError = null
+                                    )
+                                )
                                 biomarkersCount++
                             }
                         } else {
                             biomarkerDao.upsert(entity)
+                            syncStateDao.upsert(
+                                SyncStateEntity(
+                                    entityType = SyncStateEntity.TYPE_BIOMARKER_OBSERVATION,
+                                    entityId = SyncStateEntity.biomarkerEntityId(entity.date),
+                                    clientRev = UUID.randomUUID().toString(),
+                                    createdAtEpochMillis = updatedAtMillis,
+                                    updatedAtEpochMillis = now,
+                                    dirty = true,
+                                    lastPushError = null
+                                )
+                            )
                             biomarkersCount++
                         }
-                        syncStateDao.upsert(
-                            SyncStateEntity(
-                                entityType = SyncStateEntity.TYPE_BIOMARKER_OBSERVATION,
-                                entityId = SyncStateEntity.biomarkerEntityId(entity.date),
-                                clientRev = UUID.randomUUID().toString(),
-                                createdAtEpochMillis = updatedAtMillis,
-                                updatedAtEpochMillis = now,
-                                dirty = true,
-                                lastPushError = null
-                            )
-                        )
                     }
 
                     if (strategy == ImportStrategy.REPLACE_ALL) {

--- a/app/src/main/java/fr/luteal/core/data/local/LutealDatabase.kt
+++ b/app/src/main/java/fr/luteal/core/data/local/LutealDatabase.kt
@@ -141,13 +141,13 @@ abstract class LutealDatabase : RoomDatabase() {
                         date TEXT NOT NULL PRIMARY KEY,
                         bbtCelsius REAL,
                         bbtTime TEXT,
-                        bbtQuality TEXT NOT NULL DEFAULT 'normal',
-                        bbtDisturbancesJson TEXT NOT NULL DEFAULT '[]',
+                        bbtQuality TEXT NOT NULL,
+                        bbtDisturbancesJson TEXT NOT NULL,
                         cervicalSensation TEXT,
                         cervicalTexture TEXT,
                         lhTestResult TEXT,
                         hcgTestResult TEXT,
-                        notes TEXT NOT NULL DEFAULT '',
+                        notes TEXT NOT NULL,
                         updatedAtEpochMillis INTEGER NOT NULL
                     )
                     """.trimIndent()

--- a/app/src/main/java/fr/luteal/core/data/repository/CycleRepository.kt
+++ b/app/src/main/java/fr/luteal/core/data/repository/CycleRepository.kt
@@ -2,6 +2,7 @@ package fr.luteal.core.data.repository
 
 import fr.luteal.core.model.Cycle
 import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
 
 interface CycleRepository {
     fun getCycles(): Flow<List<Cycle>>
@@ -17,4 +18,7 @@ interface CycleRepository {
     suspend fun upsertCycle(cycle: Cycle)
     suspend fun deleteCycle(id: String)
     suspend fun updateCycleExclusion(id: String, isExcluded: Boolean, reason: fr.luteal.core.model.CycleExclusionReason?)
+    suspend fun addBackfilledCycle(startDate: LocalDate)
+    suspend fun editCycleStartDate(cycleId: String, newStartDate: LocalDate)
+    suspend fun deleteCycleAndReconcile(cycleId: String)
 }

--- a/app/src/main/java/fr/luteal/core/data/repository/CycleRepositoryImpl.kt
+++ b/app/src/main/java/fr/luteal/core/data/repository/CycleRepositoryImpl.kt
@@ -2,14 +2,17 @@ package fr.luteal.core.data.repository
 
 import androidx.room.withTransaction
 import fr.luteal.core.data.entity.CycleEntity
+import fr.luteal.core.data.entity.DailyEntryEntity
 import fr.luteal.core.data.entity.SyncStateEntity
 import fr.luteal.core.data.local.CycleDao
+import fr.luteal.core.data.local.DailyEntryDao
 import fr.luteal.core.data.local.LutealDatabase
 import fr.luteal.core.data.local.SyncStateDao
 import fr.luteal.core.model.BleedingIntensity
 import fr.luteal.core.model.Cycle
 import fr.luteal.core.model.PeriodDay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import org.json.JSONArray
 import org.json.JSONObject
@@ -23,24 +26,27 @@ import javax.inject.Singleton
 class CycleRepositoryImpl @Inject constructor(
     private val database: LutealDatabase,
     private val cycleDao: CycleDao,
+    private val dailyEntryDao: DailyEntryDao,
     private val syncStateDao: SyncStateDao,
     private val clock: Clock
 ) : CycleRepository {
 
     override fun getCycles(): Flow<List<Cycle>> {
-        return cycleDao.getAllCycles().map { entities ->
-            entities.map { it.toDomain() }
+        return combine(cycleDao.getAllCycles(), dailyEntryDao.observeEntries()) { cycleEntities, dailyEntries ->
+            cycleEntities.map { it.toDomain(dailyEntries) }
         }
     }
 
     override fun getCurrentCycle(): Flow<Cycle?> {
-        return cycleDao.getCurrentCycle().map { entity ->
-            entity?.toDomain()
+        return combine(cycleDao.getCurrentCycle(), dailyEntryDao.observeEntries()) { entity, dailyEntries ->
+            entity?.toDomain(dailyEntries)
         }
     }
 
     override suspend fun getCyclesOnce(): List<Cycle> {
-        return cycleDao.getAllCyclesOnce().map { it.toDomain() }
+        val cycleEntities = cycleDao.getAllCyclesOnce()
+        val dailyEntries = dailyEntryDao.getAllEntriesOnce()
+        return cycleEntities.map { it.toDomain(dailyEntries) }
     }
 
     override suspend fun saveCycle(cycle: Cycle) {
@@ -92,6 +98,82 @@ class CycleRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun addBackfilledCycle(startDate: LocalDate) {
+        database.withTransaction {
+            val existing = cycleDao.getAllCyclesOnce()
+            require(existing.none { LocalDate.parse(it.startDate) == startDate }) {
+                "Un cycle existe déjà à cette date."
+            }
+
+            val newCycle = CycleEntity(
+                id = UUID.randomUUID().toString(),
+                startDate = startDate.toString(),
+                endDate = null,
+                periodDaysJson = "[]",
+                averageLengthDays = 28,
+                lutealPhaseLengthDays = 14,
+                isSynced = false,
+                isExcludedFromEstimates = false,
+                exclusionReason = null
+            )
+
+            val updatedList = (existing + newCycle).sortedBy { LocalDate.parse(it.startDate) }
+
+            for (i in updatedList.indices) {
+                val current = updatedList[i]
+                val nextStart = updatedList.getOrNull(i + 1)?.let { LocalDate.parse(it.startDate) }
+                val newEndDate = nextStart?.minusDays(1)?.toString()
+                if (current.id == newCycle.id || current.endDate != newEndDate) {
+                    cycleDao.insertCycle(current.copy(endDate = newEndDate))
+                    markDirty(current.id)
+                }
+            }
+        }
+    }
+
+    override suspend fun editCycleStartDate(cycleId: String, newStartDate: LocalDate) {
+        database.withTransaction {
+            val existing = cycleDao.getAllCyclesOnce()
+            val target = existing.firstOrNull { it.id == cycleId }
+                ?: error("Cycle introuvable.")
+            if (LocalDate.parse(target.startDate) == newStartDate) return@withTransaction
+
+            require(existing.none { it.id != cycleId && LocalDate.parse(it.startDate) == newStartDate }) {
+                "Un autre cycle commence déjà à cette date."
+            }
+
+            val updatedList = existing.map {
+                if (it.id == cycleId) it.copy(startDate = newStartDate.toString()) else it
+            }.sortedBy { LocalDate.parse(it.startDate) }
+
+            for (i in updatedList.indices) {
+                val current = updatedList[i]
+                val nextStart = updatedList.getOrNull(i + 1)?.let { LocalDate.parse(it.startDate) }
+                val newEndDate = nextStart?.minusDays(1)?.toString()
+                if (current.id == cycleId || current.endDate != newEndDate) {
+                    cycleDao.insertCycle(current.copy(endDate = newEndDate))
+                    markDirty(current.id)
+                }
+            }
+        }
+    }
+
+    override suspend fun deleteCycleAndReconcile(cycleId: String) {
+        database.withTransaction {
+            deleteCycle(cycleId)
+            val remaining = cycleDao.getAllCyclesOnce().sortedBy { LocalDate.parse(it.startDate) }
+            for (i in remaining.indices) {
+                val current = remaining[i]
+                val nextStart = remaining.getOrNull(i + 1)?.let { LocalDate.parse(it.startDate) }
+                val newEndDate = nextStart?.minusDays(1)?.toString()
+                if (current.endDate != newEndDate) {
+                    cycleDao.insertCycle(current.copy(endDate = newEndDate))
+                    markDirty(current.id)
+                }
+            }
+        }
+    }
+
     /**
      * Records a fresh envelope for a locally edited cycle: a new client_rev on
      * every edit (the conflict tiebreak), created_at preserved across edits,
@@ -115,17 +197,55 @@ class CycleRepositoryImpl @Inject constructor(
         )
     }
 
-    private fun CycleEntity.toDomain(): Cycle {
+    private fun CycleEntity.toDomain(entries: List<DailyEntryEntity> = emptyList()): Cycle {
+        val cycleStart = LocalDate.parse(startDate)
+        val cycleEnd = endDate?.let { LocalDate.parse(it) } ?: LocalDate.now(clock)
+
+        val bleedingPeriodDays = entries.mapNotNull { entry ->
+            val entryDate = runCatching { LocalDate.parse(entry.date) }.getOrNull() ?: return@mapNotNull null
+            if (entryDate in cycleStart..cycleEnd) {
+                val intensity = entry.bleedingIntensity?.let { stored ->
+                    BleedingIntensity.entries.firstOrNull { it.name.equals(stored, ignoreCase = true) }
+                }
+                if (intensity != null && intensity != BleedingIntensity.NONE) {
+                    PeriodDay(
+                        date = entryDate,
+                        bleedingIntensity = intensity,
+                        notes = entry.notes,
+                        symptomIds = entry.symptomIdsJson.toSymptomIds()
+                    )
+                } else null
+            } else null
+        }.sortedBy { it.date }
+
+        val resolvedPeriodDays = if (bleedingPeriodDays.isNotEmpty()) {
+            bleedingPeriodDays
+        } else {
+            periodDaysJson.toPeriodDays()
+        }
+
         return Cycle(
             id = id,
-            startDate = LocalDate.parse(startDate),
+            startDate = cycleStart,
             endDate = endDate?.let { LocalDate.parse(it) },
             averageLengthDays = averageLengthDays,
             lutealPhaseLengthDays = lutealPhaseLengthDays,
-            periodDays = periodDaysJson.toPeriodDays(),
+            periodDays = resolvedPeriodDays,
             isExcludedFromEstimates = isExcludedFromEstimates,
             exclusionReason = fr.luteal.core.model.CycleExclusionReason.fromKey(exclusionReason)
         )
+    }
+
+    private fun String.toSymptomIds(): List<String> {
+        if (isBlank()) return emptyList()
+        return runCatching {
+            val array = JSONArray(this)
+            val list = mutableListOf<String>()
+            for (i in 0 until array.length()) {
+                list.add(array.getString(i))
+            }
+            list
+        }.getOrDefault(emptyList())
     }
 
     private fun Cycle.toEntity(): CycleEntity {

--- a/app/src/main/java/fr/luteal/core/data/security/AppLockManager.kt
+++ b/app/src/main/java/fr/luteal/core/data/security/AppLockManager.kt
@@ -24,6 +24,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.ceil
 
+private const val MAX_LOCKOUT_MILLIS = 300_000L
+
 @Singleton
 class AppLockManager @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -167,11 +169,26 @@ class AppLockManager @Inject constructor(
      * defeated by rolling the device clock back; the monotonic deadline
      * ([UserPreferences.lockoutUntilElapsedRealtimeMillis], from
      * [SystemClock.elapsedRealtime]) cannot be rolled back but resets on
-     * reboot. A lockout is active while either clock says so.
+     * reboot.
+     *
+     * On reboot, [SystemClock.elapsedRealtime] resets to zero, causing
+     * [UserPreferences.lockoutUntilElapsedRealtimeMillis] - [SystemClock.elapsedRealtime]
+     * to jump to an excessively large number. Because the maximum lockout is 300 seconds,
+     * any monotonic difference exceeding 300,000 ms indicates a reboot reset and is
+     * invalidated, falling back to the wall-clock deadline.
      */
     private fun remainingLockoutSeconds(prefs: UserPreferences): Int {
         val byWallClock = prefs.lockoutUntilEpochMillis - System.currentTimeMillis()
-        val byMonotonic = prefs.lockoutUntilElapsedRealtimeMillis - SystemClock.elapsedRealtime()
+        val monotonicDiff = prefs.lockoutUntilElapsedRealtimeMillis - SystemClock.elapsedRealtime()
+        val byMonotonic = if (
+            prefs.lockoutUntilElapsedRealtimeMillis <= 0L ||
+            monotonicDiff <= 0L ||
+            monotonicDiff > MAX_LOCKOUT_MILLIS
+        ) {
+            0L
+        } else {
+            monotonicDiff
+        }
         val remainingMillis = maxOf(byWallClock, byMonotonic)
         return if (remainingMillis > 0) ceil(remainingMillis / 1000.0).toInt() else 0
     }

--- a/app/src/main/java/fr/luteal/core/model/CurrentCyclePhase.kt
+++ b/app/src/main/java/fr/luteal/core/model/CurrentCyclePhase.kt
@@ -75,17 +75,11 @@ object CurrentCyclePhaseCalculator {
         val canonicalPeriodDay = cycle.periodDays.firstOrNull { it.date == today }
         val observedFlow = canonicalPeriodDay?.bleedingIntensity ?: todayEntry?.bleedingIntensity
 
-        if (dayIndex == 0 || canonicalPeriodDay?.bleedingIntensity.isPeriodFlow()) {
+        if (dayIndex == 0 || observedFlow.isPeriodFlow()) {
             return CurrentCyclePhase.Available(CyclePhase.MENSTRUAL, PhaseCertainty.RECORDED)
         }
 
         if (dayIndex < EARLY_CYCLE_DAYS) {
-            if (observedFlow.isPeriodFlow()) {
-                return CurrentCyclePhase.Available(
-                    CyclePhase.MENSTRUAL,
-                    PhaseCertainty.RECORDED
-                )
-            }
             if (observedFlow == null || observedFlow == BleedingIntensity.SPOTTING) {
                 return CurrentCyclePhase.Indeterminate(
                     PhaseIndeterminateReason.EARLY_CYCLE_WITHOUT_BLEEDING_DETAIL
@@ -117,9 +111,11 @@ object CurrentCyclePhaseCalculator {
             ChronoUnit.DAYS.between(estimate.centralDate, estimate.latestDate)
         )
         val ovulationCentral = estimate.centralDate.minusDays(LUTEAL_ANCHOR_DAYS)
-        val ovulationRadius = nextPeriodRadius + OVULATION_EXTRA_RADIUS_DAYS
-        val ovulationEarliest = ovulationCentral.minusDays(ovulationRadius)
-        val ovulationLatest = ovulationCentral.plusDays(ovulationRadius)
+        val daysUntilEarliestPeriod = ChronoUnit.DAYS.between(ovulationCentral, estimate.earliestDate)
+        val maxOvulationRadius = maxOf(1L, daysUntilEarliestPeriod - 2)
+        val ovulationRadius = minOf(nextPeriodRadius + OVULATION_EXTRA_RADIUS_DAYS, maxOvulationRadius)
+        val ovulationEarliest = ovulationCentral.minusDays(ovulationRadius.toLong())
+        val ovulationLatest = ovulationCentral.plusDays(ovulationRadius.toLong())
 
         return when {
             today.isBefore(ovulationEarliest) -> CurrentCyclePhase.Available(

--- a/app/src/main/java/fr/luteal/core/model/CycleEstimate.kt
+++ b/app/src/main/java/fr/luteal/core/model/CycleEstimate.kt
@@ -194,22 +194,19 @@ object CycleEstimateCalculator {
         priorSdDays: Double
     ): Int {
         val n = lengths.size
-        val sampleVariance = if (n < 2) {
-            0.0
+        val priorVariance = priorSdDays * priorSdDays
+        val shrunkVariance = if (n < 2) {
+            priorVariance
         } else {
             val mean = lengths.average()
-            lengths.sumOf { (it - mean) * (it - mean) } / (n - 1)
-        }
-
-        val priorWeight = if (highVariability) {
-            PRIOR_WEIGHT_HIGH_VARIABILITY
-        } else {
-            PRIOR_WEIGHT
-        }
-
-        val priorVariance = priorSdDays * priorSdDays
-        val shrunkVariance =
+            val sampleVariance = lengths.sumOf { (it - mean) * (it - mean) } / (n - 1)
+            val priorWeight = if (highVariability) {
+                PRIOR_WEIGHT_HIGH_VARIABILITY
+            } else {
+                PRIOR_WEIGHT
+            }
             (n * sampleVariance + priorWeight * priorVariance) / (n + priorWeight)
+        }
 
         // A declared timing context guarantees at least population-level
         // uncertainty. If the user's own cycles are more variable than that,

--- a/app/src/main/java/fr/luteal/core/model/LongitudinalCycleStatsCalculator.kt
+++ b/app/src/main/java/fr/luteal/core/model/LongitudinalCycleStatsCalculator.kt
@@ -53,7 +53,9 @@ object LongitudinalCycleStatsCalculator {
             }
 
             if (!isCurrent) {
-                prevCompletedLength = length
+                if (!cycle.isExcludedFromEstimates) {
+                    prevCompletedLength = length
+                }
                 if (!cycle.isExcludedFromEstimates && length in CycleEstimateCalculator.plausibleCycleDays) {
                     completedLengths.add(length)
                 }

--- a/app/src/main/java/fr/luteal/core/model/ThermalShiftCalculator.kt
+++ b/app/src/main/java/fr/luteal/core/model/ThermalShiftCalculator.kt
@@ -1,6 +1,7 @@
 package fr.luteal.core.model
 
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 
 sealed interface ThermalShiftResult {
     data object None : ThermalShiftResult
@@ -14,7 +15,6 @@ sealed interface ThermalShiftResult {
 
 object ThermalShiftCalculator {
     private const val MIN_SHIFT_DELTA_CELSIUS = 0.20
-    private const val COVERLINE_OFFSET_CELSIUS = 0.05
 
     fun evaluateCycle(
         cycleStartDate: LocalDate,
@@ -31,6 +31,17 @@ object ThermalShiftCalculator {
         if (validTemps.size < 9) return ThermalShiftResult.None
 
         for (index in 0..(validTemps.size - 9)) {
+            val transitionValid = ChronoUnit.DAYS.between(
+                validTemps[index + 5].date,
+                validTemps[index + 6].date
+            ) <= 2
+            if (!transitionValid) continue
+
+            val continuityValid = (index until (index + 8)).all { i ->
+                ChronoUnit.DAYS.between(validTemps[i].date, validTemps[i + 1].date) <= 3
+            }
+            if (!continuityValid) continue
+
             val sixLows = validTemps.subList(index, index + 6).mapNotNull { it.bbt?.valueCelsius }
             val threeHighs = validTemps.subList(index + 6, index + 9).mapNotNull { it.bbt?.valueCelsius }
             val maxLow = sixLows.maxOrNull() ?: continue
@@ -38,7 +49,7 @@ object ThermalShiftCalculator {
             val thirdDaySignificantlyHigher = threeHighs[2] >= (maxLow + MIN_SHIFT_DELTA_CELSIUS)
             if (allThreeHigher && thirdDaySignificantlyHigher) {
                 return ThermalShiftResult.Confirmed(
-                    coverlineCelsius = maxLow + COVERLINE_OFFSET_CELSIUS,
+                    coverlineCelsius = maxLow,
                     firstHighDay = validTemps[index + 6].date,
                     baselineLowTemps = sixLows,
                     highTemps = threeHighs

--- a/app/src/main/java/fr/luteal/core/network/crypto/DuoKeyStore.kt
+++ b/app/src/main/java/fr/luteal/core/network/crypto/DuoKeyStore.kt
@@ -15,7 +15,7 @@ import javax.inject.Singleton
  * recover a key it never held.
  */
 @Singleton
-class DuoKeyStore @Inject constructor(
+open class DuoKeyStore @Inject constructor(
     @ApplicationContext context: Context
 ) {
     private companion object {
@@ -29,18 +29,18 @@ class DuoKeyStore @Inject constructor(
         keyAlias = KEY_ALIAS
     )
 
-    fun save(linkId: String, linkKey: ByteArray) {
+    open fun save(linkId: String, linkKey: ByteArray) {
         store.put(linkId, DuoCrypto.encodeKey(linkKey))
     }
 
-    fun load(linkId: String): ByteArray? =
+    open fun load(linkId: String): ByteArray? =
         store.get(linkId)?.let { runCatching { DuoCrypto.decodeKey(it) }.getOrNull() }
 
-    fun remove(linkId: String) {
+    open fun remove(linkId: String) {
         store.remove(linkId)
     }
 
-    fun clear() {
+    open fun clear() {
         store.clear()
     }
 }

--- a/app/src/main/java/fr/luteal/core/network/crypto/DuoProjectionDecoder.kt
+++ b/app/src/main/java/fr/luteal/core/network/crypto/DuoProjectionDecoder.kt
@@ -17,7 +17,7 @@ class DuoProjectionDecoder @Inject constructor(
         val key = keyStore.load(linkId) ?: return DuoProjectionDecodeResult.KeyMissing
 
         return runCatching {
-            val plaintext = DuoCrypto.open(key, linkId, String(payload))
+            val plaintext = DuoCrypto.openRaw(key, linkId, payload)
             ContractJson.decodeFromString(DuoProjection.serializer(), String(plaintext))
         }.fold(
             onSuccess = { DuoProjectionDecodeResult.Available(it) },

--- a/app/src/main/java/fr/luteal/core/network/sync/CycleSyncEngine.kt
+++ b/app/src/main/java/fr/luteal/core/network/sync/CycleSyncEngine.kt
@@ -26,6 +26,7 @@ import fr.luteal.core.network.contract.models.RecordSource
 import fr.luteal.core.network.contract.models.EntityType
 import fr.luteal.core.network.mapping.SyncMeta
 import fr.luteal.core.network.mapping.associatePeriodDays
+import fr.luteal.core.network.mapping.toBleedingIntensity
 import fr.luteal.core.network.mapping.fanOutBleeding
 import fr.luteal.core.network.mapping.toCycle
 import fr.luteal.core.network.mapping.toCycleData
@@ -73,6 +74,7 @@ interface SyncCursorStore {
      * [fr.luteal.core.network.auth.DeviceLabel].
      */
     suspend fun getDeviceLabel(): String
+    suspend fun clear() {}
 }
 
 /** Outcome of one sync pass. Contains no credentials. */
@@ -223,88 +225,102 @@ class CycleSyncEngine(
             }
         }
 
-        // No runCatching here: a 401 propagates to [sync], which converts it
-        // into a terminal SyncAuthException without touching stored
-        // credentials.
-        val result = client.syncPush(token, changes)
-
         var appliedCount = 0
-        for (applied in result.applied) {
-            val localId = localIdByWireId[applied.entityId] ?: applied.entityId.toString()
-            val pushedRev = pushedRevByWireId[applied.entityId]
-            val state = syncStateDao.getState(localId)
-            if (state != null && pushedRev != null && state.clientRev == pushedRev) {
-                // Envelope unchanged since the push snapshot: safe to ack.
-                // A concurrent local edit writes a fresh clientRev and keeps
-                // the envelope dirty, so the newer change is pushed on a
-                // later pass instead of being stranded by markClean.
-                if (state.deletedAtEpochMillis != null) {
-                    syncStateDao.deleteIfRev(localId, pushedRev)
-                } else {
-                    syncStateDao.markCleanIfRev(localId, pushedRev)
-                }
-            }
-            appliedCount++
-        }
-
-        val rejectedDetails = result.rejected.map { rejected ->
-            val wireId = rejected.entityId
-            val localId = wireId?.let { localIdByWireId[it] ?: it.toString() }
-            if (localId != null) {
-                syncStateDao.markRejected(localId, rejected.detail)
-            }
-            "${rejected.entityType.value}: ${rejected.detail}"
-        }
-
+        val rejectedDetails = mutableListOf<String>()
         var conflictsAdopted = 0
-        for (conflict in result.conflicts) {
-            when (conflict.entityType) {
-                EntityType.CYCLE -> {
-                    if (conflict.currentDeleted) {
-                        cycleRepository.deleteCycle(conflict.entityId.toString())
-                        syncStateDao.delete(conflict.entityId.toString())
-                        conflictsAdopted++
-                        continue
+
+        for (chunk in changes.chunked(500)) {
+            // No runCatching here: a 401 propagates to [sync], which converts it
+            // into a terminal SyncAuthException without touching stored
+            // credentials.
+            val result = client.syncPush(token, chunk)
+
+            for (applied in result.applied) {
+                val localId = localIdByWireId[applied.entityId] ?: applied.entityId.toString()
+                val pushedRev = pushedRevByWireId[applied.entityId]
+                val state = syncStateDao.getState(localId)
+                if (state != null && pushedRev != null && state.clientRev == pushedRev) {
+                    // Envelope unchanged since the push snapshot: safe to ack.
+                    // A concurrent local edit writes a fresh clientRev and keeps
+                    // the envelope dirty, so the newer change is pushed on a
+                    // later pass instead of being stranded by markClean.
+                    if (state.deletedAtEpochMillis != null) {
+                        syncStateDao.deleteIfRev(localId, pushedRev)
+                    } else {
+                        syncStateDao.markCleanIfRev(localId, pushedRev)
                     }
-                    val serverCycle = conflict.openCurrent(recordSealer)?.toCycleData() ?: continue
-                    val localPeriodDays = cycleRepository.getCyclesOnce()
-                        .firstOrNull { it.id == serverCycle.id.toString() }
-                        ?.periodDays.orEmpty()
-                    adoptCycle(serverCycle, localPeriodDays)
-                    conflictsAdopted++
                 }
-                EntityType.DAILY_ENTRY -> {
-                    if (conflict.currentDeleted) {
-                        adoptDailyEntryTombstone(conflict.entityId)
+                appliedCount++
+            }
+
+            for (rejected in result.rejected) {
+                val wireId = rejected.entityId
+                val localId = wireId?.let { localIdByWireId[it] ?: it.toString() }
+                if (localId != null) {
+                    syncStateDao.markRejected(localId, rejected.detail)
+                }
+                rejectedDetails += "${rejected.entityType.value}: ${rejected.detail}"
+            }
+
+            for (conflict in result.conflicts) {
+                when (conflict.entityType) {
+                    EntityType.CYCLE -> {
+                        if (conflict.currentDeleted) {
+                            cycleRepository.deleteCycle(conflict.entityId.toString())
+                            syncStateDao.delete(conflict.entityId.toString())
+                            conflictsAdopted++
+                            continue
+                        }
+                        val serverCycle = conflict.openCurrent(recordSealer)?.toCycleData() ?: continue
+                        val localPeriodDays = cycleRepository.getCyclesOnce()
+                            .firstOrNull { it.id == serverCycle.id.toString() }
+                            ?.periodDays.orEmpty()
+                        adoptCycle(serverCycle, localPeriodDays)
                         conflictsAdopted++
-                        continue
                     }
-                    val serverEntry = conflict.openCurrent(recordSealer)?.toDailyEntryData() ?: continue
-                    adoptDailyEntry(serverEntry)
-                    conflictsAdopted++
-                }
-                EntityType.SYMPTOM_LOG -> {
-                    if (conflict.currentDeleted) {
-                        symptomDao.deleteSymptomLog(conflict.entityId.toString())
-                        syncStateDao.delete(conflict.entityId.toString())
+                    EntityType.DAILY_ENTRY -> {
+                        if (conflict.currentDeleted) {
+                            adoptDailyEntryTombstone(conflict.entityId)
+                            conflictsAdopted++
+                            continue
+                        }
+                        val serverEntry = conflict.openCurrent(recordSealer)?.toDailyEntryData() ?: continue
+                        adoptDailyEntry(serverEntry)
                         conflictsAdopted++
-                        continue
                     }
-                    val serverLog = conflict.openCurrent(recordSealer)?.toSymptomLogData() ?: continue
-                    adoptSymptomLog(serverLog)
-                    conflictsAdopted++
-                }
-                EntityType.BIOMARKER_OBSERVATION -> {
-                    if (conflict.currentDeleted) {
-                        adoptBiomarkerTombstone(conflict.entityId)
+                    EntityType.SYMPTOM_LOG -> {
+                        if (conflict.currentDeleted) {
+                            symptomDao.deleteSymptomLog(conflict.entityId.toString())
+                            syncStateDao.delete(conflict.entityId.toString())
+                            conflictsAdopted++
+                            continue
+                        }
+                        val serverLog = conflict.openCurrent(recordSealer)?.toSymptomLogData() ?: continue
+                        adoptSymptomLog(serverLog)
                         conflictsAdopted++
-                        continue
                     }
-                    val server = conflict.openCurrent(recordSealer)?.toBiomarkerObservationPayload() ?: continue
-                    adoptBiomarker(server)
-                    conflictsAdopted++
+                    EntityType.BIOMARKER_OBSERVATION -> {
+                        if (conflict.currentDeleted) {
+                            adoptBiomarkerTombstone(conflict.entityId)
+                            conflictsAdopted++
+                            continue
+                        }
+                        val server = conflict.openCurrent(recordSealer)?.toBiomarkerObservationPayload() ?: continue
+                        adoptBiomarker(server)
+                        conflictsAdopted++
+                    }
+                    EntityType.BLEEDING_OBSERVATION -> {
+                        if (conflict.currentDeleted) {
+                            adoptBleedingObservationTombstone(conflict.entityId)
+                            conflictsAdopted++
+                            continue
+                        }
+                        val serverObs = conflict.openCurrent(recordSealer)?.toBleedingObservationData() ?: continue
+                        adoptBleedingObservation(serverObs)
+                        conflictsAdopted++
+                    }
+                    else -> { /* other conflicts are ignored or resolved via re-pull */ }
                 }
-                else -> { /* bleeding conflicts are resolved via cycle re-pull */ }
             }
         }
 
@@ -524,6 +540,7 @@ class CycleSyncEngine(
                     val cycleId = change.entityId.toString()
                     if (change.deleted) {
                         cycleRepository.deleteCycle(cycleId)
+                        syncStateDao.delete(cycleId)
                         tombstones++
                     } else {
                         val cycleData = runCatching {
@@ -577,13 +594,23 @@ class CycleSyncEngine(
                         recordsApplied++
                     }
                 }
+                EntityType.BLEEDING_OBSERVATION -> {
+                    if (change.deleted) {
+                        adoptBleedingObservationTombstone(change.entityId)
+                        tombstones++
+                    } else {
+                        val observation = runCatching {
+                            change.openPayload(recordSealer)?.toBleedingObservationData()
+                        }.getOrNull() ?: continue
+                        adoptBleedingObservation(observation)
+                        recordsApplied++
+                    }
+                }
                 else -> {
-                    // BLEEDING_OBSERVATION and other types are handled via their
-                    // parent entity (cycle period-day association above).
+                    // Unknown or unsupported types are skipped.
                 }
             }
         }
-
         return PageOutcome(recordsApplied, tombstones)
     }
 
@@ -604,14 +631,15 @@ class CycleSyncEngine(
 
     private suspend fun adoptDailyEntry(entryData: fr.luteal.core.network.contract.models.DailyEntryData) {
         val entry = entryData.toDailyEntry()
+        val existing = dailyEntryDao.getEntryOnce(entry.date.toString())
         dailyEntryDao.upsert(
             DailyEntryEntity(
                 date = entry.date.toString(),
-                bleedingIntensity = null, // bleeding comes via bleeding_observations
+                bleedingIntensity = entry.bleedingIntensity?.name ?: existing?.bleedingIntensity,
                 painLevel = entry.painLevel,
                 moodLevel = entry.moodLevel,
                 energyLevel = entry.energyLevel,
-                symptomIdsJson = "[]",
+                symptomIdsJson = existing?.symptomIdsJson ?: "[]",
                 notes = entry.notes,
                 updatedAtEpochMillis = entry.updatedAt.toEpochMilli()
             )
@@ -697,6 +725,58 @@ class CycleSyncEngine(
         syncStateDao.delete(wireId.toString())
     }
 
+    private suspend fun adoptBleedingObservation(observation: fr.luteal.core.network.contract.models.BleedingObservationData) {
+        val dateStr = observation.observedDate.toString()
+        val intensity = observation.flow.toBleedingIntensity()
+        val existing = dailyEntryDao.getEntryOnce(dateStr)
+        if (existing != null) {
+            dailyEntryDao.upsert(
+                existing.copy(
+                    bleedingIntensity = intensity.name,
+                    updatedAtEpochMillis = maxOf(existing.updatedAtEpochMillis, observation.updatedAt.toInstant().toEpochMilli())
+                )
+            )
+        } else {
+            dailyEntryDao.upsert(
+                DailyEntryEntity(
+                    date = dateStr,
+                    bleedingIntensity = intensity.name,
+                    painLevel = null,
+                    moodLevel = null,
+                    energyLevel = null,
+                    symptomIdsJson = "[]",
+                    notes = observation.notes,
+                    updatedAtEpochMillis = observation.updatedAt.toInstant().toEpochMilli()
+                )
+            )
+        }
+        syncStateDao.upsert(
+            SyncStateEntity(
+                entityId = observation.id.toString(),
+                entityType = SyncStateEntity.TYPE_BLEEDING_OBSERVATION,
+                clientRev = observation.clientRev.toString(),
+                createdAtEpochMillis = observation.createdAt.toInstant().toEpochMilli(),
+                updatedAtEpochMillis = observation.updatedAt.toInstant().toEpochMilli(),
+                deletedAtEpochMillis = observation.deletedAt?.toInstant()?.toEpochMilli(),
+                dirty = false,
+                lastPushError = null
+            )
+        )
+    }
+
+    private suspend fun adoptBleedingObservationTombstone(wireId: UUID) {
+        val date = dailyEntryDao.getAllEntriesOnce().firstOrNull {
+            deterministicId("bleeding", it.date) == wireId
+        }?.date
+        if (date != null) {
+            val existing = dailyEntryDao.getEntryOnce(date)
+            if (existing != null) {
+                dailyEntryDao.upsert(existing.copy(bleedingIntensity = null))
+            }
+        }
+        syncStateDao.delete(wireId.toString())
+    }
+
     private suspend fun resolveBiomarkerLocalId(wireId: UUID): String? {
         syncStateDao.getAllStates()
             .firstOrNull { it.entityType == SyncStateEntity.TYPE_BIOMARKER_OBSERVATION && wireIdFor(it) == wireId }
@@ -708,7 +788,7 @@ class CycleSyncEngine(
     }
 
     private fun wireIdFor(state: SyncStateEntity): UUID? = when (state.entityType) {
-        SyncStateEntity.TYPE_CYCLE, SyncStateEntity.TYPE_SYMPTOM_LOG ->
+        SyncStateEntity.TYPE_CYCLE, SyncStateEntity.TYPE_SYMPTOM_LOG, SyncStateEntity.TYPE_BLEEDING_OBSERVATION ->
             runCatching { UUID.fromString(state.entityId) }.getOrNull()
         SyncStateEntity.TYPE_DAILY_ENTRY ->
             runCatching { LocalDate.parse(state.entityId) }.getOrNull()

--- a/app/src/main/java/fr/luteal/core/network/sync/DataStoreSyncCursorStore.kt
+++ b/app/src/main/java/fr/luteal/core/network/sync/DataStoreSyncCursorStore.kt
@@ -31,4 +31,8 @@ class DataStoreSyncCursorStore(
         syncDataStore.setDeviceLabel(generated)
         return generated
     }
+
+    override suspend fun clear() {
+        syncDataStore.clear()
+    }
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -283,6 +283,7 @@
     <string name="settings_sync_account_code_copy">Copier le code</string>
     <string name="settings_sync_account_code_copied">Code copié</string>
     <string name="settings_sync_account_code_none">Aucun compte enregistré. Le compte sera créé lors de la première synchronisation.</string>
+    <string name="settings_sync_unlink">Déconnecter la synchronisation</string>
     <string name="settings_recovery_title">Restaurer un compte existant</string>
     <string name="settings_recovery_body">Sur un nouvel appareil, saisissez le code de compte conservé lors de la création. C’est le seul moyen de retrouver vos données : elles sont chiffrées avec ce code, et le serveur ne peut pas les déchiffrer sans lui.</string>
     <string name="settings_recovery_label">Code de compte</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -287,6 +287,7 @@
     <string name="settings_sync_account_code_copy">Copy code</string>
     <string name="settings_sync_account_code_copied">Code copied</string>
     <string name="settings_sync_account_code_none">No account registered. The account will be created on the first sync.</string>
+    <string name="settings_sync_unlink">Disconnect cloud sync</string>
     <string name="settings_recovery_title">Restore an existing account</string>
     <string name="settings_recovery_body">On a new device, enter the account code you saved when you created it. This is the only way to recover your data: it is encrypted with that code, and the server cannot decrypt it without you.</string>
     <string name="settings_recovery_label">Account code</string>

--- a/app/src/test/java/fr/luteal/app/LutealUiStateTest.kt
+++ b/app/src/test/java/fr/luteal/app/LutealUiStateTest.kt
@@ -1,0 +1,88 @@
+package fr.luteal.app
+
+import fr.luteal.core.model.Cycle
+import fr.luteal.core.model.CycleEstimate
+import fr.luteal.core.model.CycleEstimateResult
+import fr.luteal.core.model.CurrentCyclePhase
+import fr.luteal.core.model.DailyEntry
+import fr.luteal.core.model.PhaseCertainty
+import fr.luteal.core.model.PhaseIndeterminateReason
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LutealUiStateTest {
+
+    @Test
+    fun defaultInitializationState() {
+        val today = LocalDate.of(2026, 9, 2)
+        val defaultState = LutealUiState(today = today)
+
+        assertFalse(defaultState.isInitializing)
+        assertNull(defaultState.todayEntry)
+        assertNull(defaultState.dayOfCycle)
+        assertNull(defaultState.estimate)
+        assertEquals(
+            CurrentCyclePhase.Indeterminate(PhaseIndeterminateReason.NO_CURRENT_CYCLE),
+            defaultState.currentPhase
+        )
+
+        val coldStartState = LutealUiState(today = today, isInitializing = true)
+        assertTrue(coldStartState.isInitializing)
+    }
+
+    @Test
+    fun precomputedValuesAreStoredDirectly() {
+        val today = LocalDate.of(2026, 9, 2)
+        val cycle = Cycle(id = "cycle-1", startDate = today.minusDays(10))
+        val todayEntry = DailyEntry(date = today)
+        val estimate = CycleEstimate(
+            earliestDate = today.plusDays(15),
+            centralDate = today.plusDays(18),
+            latestDate = today.plusDays(21),
+            cycleCount = 4,
+            variabilityDays = 3
+        )
+        val phase = CurrentCyclePhase.Available(
+            phase = fr.luteal.core.model.CyclePhase.FOLLICULAR,
+            certainty = PhaseCertainty.ESTIMATED
+        )
+
+        val state = LutealUiState(
+            today = today,
+            cycles = listOf(cycle),
+            currentCycle = cycle,
+            entries = listOf(todayEntry),
+            isInitializing = false,
+            todayEntry = todayEntry,
+            dayOfCycle = 11,
+            estimate = estimate,
+            currentPhase = phase
+        )
+
+        assertFalse(state.isInitializing)
+        assertEquals(todayEntry, state.todayEntry)
+        assertEquals(11, state.dayOfCycle)
+        assertEquals(estimate, state.estimate)
+        assertEquals(phase, state.currentPhase)
+    }
+
+    @Test
+    fun defaultsDeriveValuesWhenNotPassedExplicitly() {
+        val today = LocalDate.of(2026, 9, 2)
+        val cycle = Cycle(id = "cycle-1", startDate = today.minusDays(4))
+        val todayEntry = DailyEntry(date = today)
+
+        val state = LutealUiState(
+            today = today,
+            currentCycle = cycle,
+            entries = listOf(todayEntry)
+        )
+
+        assertEquals(todayEntry, state.todayEntry)
+        assertEquals(5, state.dayOfCycle)
+    }
+}

--- a/app/src/test/java/fr/luteal/app/PendingBackupStoreTest.kt
+++ b/app/src/test/java/fr/luteal/app/PendingBackupStoreTest.kt
@@ -1,0 +1,38 @@
+package fr.luteal.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class PendingBackupStoreTest {
+
+    @Before
+    fun setUp() {
+        // Drain any lingering state before each test
+        PendingBackupStore.consume()
+    }
+
+    @Test
+    fun `consume returns null when store is empty`() {
+        assertNull(PendingBackupStore.consume())
+    }
+
+    @Test
+    fun `set stores json and consume retrieves and clears it`() {
+        val payload = """{"version":1,"entries":[]}"""
+        PendingBackupStore.set(payload)
+
+        assertEquals(payload, PendingBackupStore.consume())
+        assertNull(PendingBackupStore.consume())
+    }
+
+    @Test
+    fun `second set overwrites unconsumed json`() {
+        PendingBackupStore.set("first")
+        PendingBackupStore.set("second")
+
+        assertEquals("second", PendingBackupStore.consume())
+        assertNull(PendingBackupStore.consume())
+    }
+}

--- a/app/src/test/java/fr/luteal/core/data/ClinicalReportAggregatorTest.kt
+++ b/app/src/test/java/fr/luteal/core/data/ClinicalReportAggregatorTest.kt
@@ -130,4 +130,81 @@ class ClinicalReportAggregatorTest {
         assertTrue(html.contains("Crampes utérines"))
         assertTrue(html.contains("Heavy pain"))
     }
+
+    @Test
+    fun historicalCyclesWithoutEndDateDoNotLeakFutureEntries() = runTest {
+        database.cycleDao().insertCycle(
+            CycleEntity(id = "c1", startDate = "2026-05-01", endDate = null, averageLengthDays = 28, lutealPhaseLengthDays = 14, periodDaysJson = "[]")
+        )
+        database.cycleDao().insertCycle(
+            CycleEntity(id = "c2", startDate = "2026-05-29", endDate = "2026-06-25", averageLengthDays = 28, lutealPhaseLengthDays = 14, periodDaysJson = "[]")
+        )
+
+        // Entries within c1 range (2026-05-01 to 2026-05-28)
+        database.dailyEntryDao().upsert(
+            DailyEntryEntity(date = "2026-05-01", bleedingIntensity = "HEAVY", painLevel = 3, moodLevel = 3, energyLevel = 3, symptomIdsJson = "[]", notes = "", updatedAtEpochMillis = 1000L)
+        )
+        database.dailyEntryDao().upsert(
+            DailyEntryEntity(date = "2026-05-28", bleedingIntensity = "SPOTTING", painLevel = 1, moodLevel = 3, energyLevel = 3, symptomIdsJson = "[]", notes = "", updatedAtEpochMillis = 1000L)
+        )
+
+        // Entries within c2 range (2026-05-29 to 2026-06-25)
+        database.dailyEntryDao().upsert(
+            DailyEntryEntity(date = "2026-05-29", bleedingIntensity = "HEAVY", painLevel = 4, moodLevel = 3, energyLevel = 3, symptomIdsJson = "[]", notes = "", updatedAtEpochMillis = 1000L)
+        )
+        database.dailyEntryDao().upsert(
+            DailyEntryEntity(date = "2026-06-10", bleedingIntensity = "NONE", painLevel = 2, moodLevel = 3, energyLevel = 3, symptomIdsJson = "[]", notes = "", updatedAtEpochMillis = 1000L)
+        )
+
+        val config = ClinicalReportConfig(preset = ReportDateRangePreset.ALL_CYCLES)
+        val data = aggregator.aggregate(config, now = LocalDate.of(2026, 7, 1))
+
+        assertEquals(2, data.cycleStats.cycles.size)
+
+        val c1Row = data.cycleStats.cycles.first { it.cycleId == "c1" }
+        assertEquals(LocalDate.of(2026, 5, 28), c1Row.endDate)
+        assertEquals(28, c1Row.lengthDays)
+        assertEquals(2, c1Row.bleedingDaysCount)
+        assertEquals(2, c1Row.painDaysCount)
+
+        val c2Row = data.cycleStats.cycles.first { it.cycleId == "c2" }
+        assertEquals(LocalDate.of(2026, 6, 25), c2Row.endDate)
+        assertEquals(28, c2Row.lengthDays)
+        assertEquals(1, c2Row.bleedingDaysCount)
+        assertEquals(2, c2Row.painDaysCount)
+    }
+
+    @Test
+    fun excludedAndImplausibleCyclesDoNotSkewCompletedCycleStatistics() = runTest {
+        database.cycleDao().insertCycle(
+            CycleEntity(id = "c1", startDate = "2026-01-01", endDate = "2026-01-28", averageLengthDays = 28, lutealPhaseLengthDays = 14, periodDaysJson = "[]")
+        )
+        database.cycleDao().insertCycle(
+            CycleEntity(id = "c2", startDate = "2026-01-29", endDate = "2026-02-27", averageLengthDays = 30, lutealPhaseLengthDays = 14, periodDaysJson = "[]")
+        )
+        database.cycleDao().insertCycle(
+            CycleEntity(
+                id = "c3",
+                startDate = "2026-02-28",
+                endDate = "2026-04-28",
+                averageLengthDays = 60,
+                lutealPhaseLengthDays = 14,
+                periodDaysJson = "[]",
+                isExcludedFromEstimates = true,
+                exclusionReason = "PREGNANCY"
+            )
+        )
+        database.cycleDao().insertCycle(
+            CycleEntity(id = "c4", startDate = "2026-04-29", endDate = "2026-05-08", averageLengthDays = 10, lutealPhaseLengthDays = 5, periodDaysJson = "[]")
+        )
+
+        val config = ClinicalReportConfig(preset = ReportDateRangePreset.ALL_CYCLES)
+        val data = aggregator.aggregate(config, now = LocalDate.of(2026, 6, 1))
+
+        assertEquals(4, data.cycleStats.totalCyclesCount)
+        assertEquals(2, data.cycleStats.completedCyclesCount)
+        assertEquals(29.0, data.cycleStats.meanLengthDays!!, 0.01)
+        assertEquals(LocalDate.of(2026, 1, 1), data.cycleStats.shortestCycleDate)
+        assertEquals(LocalDate.of(2026, 1, 29), data.cycleStats.longestCycleDate)
+    }
 }

--- a/app/src/test/java/fr/luteal/core/data/DataImportManagerTest.kt
+++ b/app/src/test/java/fr/luteal/core/data/DataImportManagerTest.kt
@@ -9,6 +9,9 @@ import fr.luteal.core.data.entity.CycleEntity
 import fr.luteal.core.data.entity.DailyEntryEntity
 import fr.luteal.core.data.entity.SymptomLogEntity
 import fr.luteal.core.data.local.LutealDatabase
+import fr.luteal.core.data.entity.BiomarkerObservationEntity
+import fr.luteal.core.data.entity.SyncStateEntity
+import fr.luteal.core.model.BiomarkerBackupDto
 import fr.luteal.core.model.CycleBackupDto
 import fr.luteal.core.model.DailyEntryBackupDto
 import fr.luteal.core.model.DataImportError
@@ -435,5 +438,148 @@ class DataImportManagerTest {
         assertTrue(restoreResult.exceptionOrNull() is DataImportError.CorruptedPayload)
         // Nothing was persisted: the database stays untouched.
         assertTrue(database.cycleDao().getAllCyclesOnce().isEmpty())
+    }
+
+    @Test
+    fun mergeUpsertSkipsOlderDailyEntryAndPreservesSyncStateEnvelope() = runTest {
+        val date = "2026-06-01"
+        val localUpdatedAt = Instant.parse("2026-06-01T20:00:00Z").toEpochMilli()
+
+        database.dailyEntryDao().upsert(
+            DailyEntryEntity(
+                date = date,
+                bleedingIntensity = "HEAVY",
+                painLevel = 4,
+                moodLevel = 2,
+                energyLevel = 3,
+                symptomIdsJson = "[\"cramps\"]",
+                notes = "Local newer entry",
+                updatedAtEpochMillis = localUpdatedAt
+            )
+        )
+
+        val localSyncState = SyncStateEntity(
+            entityType = SyncStateEntity.TYPE_DAILY_ENTRY,
+            entityId = date,
+            clientRev = "local-client-rev-123",
+            createdAtEpochMillis = localUpdatedAt,
+            updatedAtEpochMillis = localUpdatedAt,
+            dirty = false,
+            lastPushError = null
+        )
+        database.syncStateDao().upsert(localSyncState)
+
+        val payload = LutealBackupPayload(
+            schemaVersion = 1,
+            exportedAt = "2026-08-15T12:00:00Z",
+            appVersion = "1.2.0",
+            cycles = emptyList(),
+            dailyEntries = listOf(
+                DailyEntryBackupDto(
+                    date = date,
+                    bleedingIntensity = "LIGHT",
+                    painLevel = 1,
+                    moodLevel = 5,
+                    energyLevel = 5,
+                    symptomIds = emptyList(),
+                    notes = "Older backup entry",
+                    updatedAt = "2026-06-01T10:00:00Z"
+                )
+            ),
+            symptomLogs = emptyList(),
+            biomarkerObservations = emptyList()
+        )
+
+        val result = importManager.restoreBackup(payload, ImportStrategy.MERGE_UPSERT)
+        assertTrue(result.isSuccess)
+        assertEquals(0, result.getOrThrow().dailyEntriesImported)
+
+        val persistedEntry = database.dailyEntryDao().getEntryOnce(date)
+        assertNotNull(persistedEntry)
+        assertEquals("Local newer entry", persistedEntry?.notes)
+        assertEquals("HEAVY", persistedEntry?.bleedingIntensity)
+        assertEquals(localUpdatedAt, persistedEntry?.updatedAtEpochMillis)
+
+        val persistedSyncState = database.syncStateDao().getState(date)
+        assertNotNull(persistedSyncState)
+        assertEquals("local-client-rev-123", persistedSyncState?.clientRev)
+        assertEquals(localUpdatedAt, persistedSyncState?.createdAtEpochMillis)
+        assertEquals(localUpdatedAt, persistedSyncState?.updatedAtEpochMillis)
+        assertEquals(false, persistedSyncState?.dirty)
+    }
+
+    @Test
+    fun mergeUpsertSkipsOlderBiomarkerObservationAndPreservesSyncStateEnvelope() = runTest {
+        val date = "2026-06-01"
+        val localUpdatedAt = Instant.parse("2026-06-01T20:00:00Z").toEpochMilli()
+        val syncEntityId = SyncStateEntity.biomarkerEntityId(date)
+
+        database.biomarkerDao().upsert(
+            BiomarkerObservationEntity(
+                date = date,
+                bbtCelsius = 36.6,
+                bbtTime = "07:00",
+                bbtQuality = "normal",
+                bbtDisturbancesJson = "[]",
+                cervicalSensation = "wet",
+                cervicalTexture = "egg_white",
+                lhTestResult = "positive",
+                hcgTestResult = null,
+                notes = "Local newer biomarker",
+                updatedAtEpochMillis = localUpdatedAt
+            )
+        )
+
+        val localSyncState = SyncStateEntity(
+            entityType = SyncStateEntity.TYPE_BIOMARKER_OBSERVATION,
+            entityId = syncEntityId,
+            clientRev = "local-biomarker-rev-456",
+            createdAtEpochMillis = localUpdatedAt,
+            updatedAtEpochMillis = localUpdatedAt,
+            dirty = false,
+            lastPushError = null
+        )
+        database.syncStateDao().upsert(localSyncState)
+
+        val payload = LutealBackupPayload(
+            schemaVersion = 1,
+            exportedAt = "2026-08-15T12:00:00Z",
+            appVersion = "1.2.0",
+            cycles = emptyList(),
+            dailyEntries = emptyList(),
+            symptomLogs = emptyList(),
+            biomarkerObservations = listOf(
+                BiomarkerBackupDto(
+                    date = date,
+                    bbtCelsius = 36.2,
+                    bbtTime = "06:30",
+                    bbtQuality = "normal",
+                    bbtDisturbances = emptyList(),
+                    cervicalSensation = "dry",
+                    cervicalTexture = "sticky",
+                    lhTestResult = "negative",
+                    hcgTestResult = null,
+                    notes = "Older backup biomarker",
+                    updatedAt = "2026-06-01T08:00:00Z"
+                )
+            )
+        )
+
+        val result = importManager.restoreBackup(payload, ImportStrategy.MERGE_UPSERT)
+        assertTrue(result.isSuccess)
+        assertEquals(0, result.getOrThrow().biomarkersImported)
+
+        val persistedBiomarker = database.biomarkerDao().getObservationOnce(date)
+        assertNotNull(persistedBiomarker)
+        assertEquals("Local newer biomarker", persistedBiomarker?.notes)
+        assertEquals(36.6, persistedBiomarker?.bbtCelsius)
+        assertEquals(localUpdatedAt, persistedBiomarker?.updatedAtEpochMillis)
+
+        val persistedSyncState = database.syncStateDao().getState(syncEntityId)
+        assertNotNull(persistedSyncState)
+        assertEquals("local-biomarker-rev-456", persistedSyncState?.clientRev)
+        assertEquals(localUpdatedAt, persistedSyncState?.createdAtEpochMillis)
+        assertEquals(localUpdatedAt, persistedSyncState?.updatedAtEpochMillis)
+        assertEquals(false, persistedSyncState?.dirty)
     }
 }

--- a/app/src/test/java/fr/luteal/core/data/repository/CycleRepositoryTest.kt
+++ b/app/src/test/java/fr/luteal/core/data/repository/CycleRepositoryTest.kt
@@ -3,9 +3,13 @@ package fr.luteal.core.data.repository
 import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import fr.luteal.core.data.entity.DailyEntryEntity
 import fr.luteal.core.data.local.LutealDatabase
+import fr.luteal.core.model.BleedingIntensity
 import fr.luteal.core.model.Cycle
 import fr.luteal.core.model.CycleExclusionReason
+import fr.luteal.core.model.PeriodDay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -40,7 +44,7 @@ class CycleRepositoryTest {
         database = Room.inMemoryDatabaseBuilder(context, LutealDatabase::class.java)
             .allowMainThreadQueries()
             .build()
-        repo = CycleRepositoryImpl(database, database.cycleDao(), database.syncStateDao(), clock)
+        repo = CycleRepositoryImpl(database, database.cycleDao(), database.dailyEntryDao(), database.syncStateDao(), clock)
     }
 
     @After
@@ -106,5 +110,148 @@ class CycleRepositoryTest {
         val state = database.syncStateDao().getState("cycle-1")
         assertNotNull(state)
         assertTrue(state!!.dirty)
+    }
+
+    @Test
+    fun getCyclesPopulatesPeriodDaysFromDailyEntriesAndFallsBack() = runTest {
+        val fallbackDays = listOf(
+            PeriodDay(LocalDate.parse("2026-06-01"), BleedingIntensity.SPOTTING)
+        )
+        val cycle = Cycle(
+            id = "c1",
+            startDate = LocalDate.parse("2026-06-01"),
+            endDate = LocalDate.parse("2026-06-28"),
+            periodDays = fallbackDays
+        )
+        repo.saveCycle(cycle)
+
+        // When no daily entries exist, fallback to saved periodDays
+        val initialCycles = repo.getCycles().first()
+        assertEquals(1, initialCycles.size)
+        assertEquals(fallbackDays, initialCycles.first().periodDays)
+
+        // Insert daily entries: within range with bleeding, within range NONE, and outside range
+        database.dailyEntryDao().upsert(
+            DailyEntryEntity(
+                date = "2026-06-01",
+                bleedingIntensity = BleedingIntensity.HEAVY.name,
+                painLevel = 1,
+                moodLevel = 2,
+                energyLevel = 3,
+                symptomIdsJson = "[\"cramps\"]",
+                notes = "Day 1",
+                updatedAtEpochMillis = clock.millis()
+            )
+        )
+        database.dailyEntryDao().upsert(
+            DailyEntryEntity(
+                date = "2026-06-02",
+                bleedingIntensity = BleedingIntensity.LIGHT.name,
+                painLevel = null,
+                moodLevel = null,
+                energyLevel = null,
+                symptomIdsJson = "[]",
+                notes = "",
+                updatedAtEpochMillis = clock.millis()
+            )
+        )
+        database.dailyEntryDao().upsert(
+            DailyEntryEntity(
+                date = "2026-06-03",
+                bleedingIntensity = BleedingIntensity.NONE.name,
+                painLevel = null,
+                moodLevel = null,
+                energyLevel = null,
+                symptomIdsJson = "[]",
+                notes = "",
+                updatedAtEpochMillis = clock.millis()
+            )
+        )
+        database.dailyEntryDao().upsert(
+            DailyEntryEntity(
+                date = "2026-07-01",
+                bleedingIntensity = BleedingIntensity.MEDIUM.name,
+                painLevel = null,
+                moodLevel = null,
+                energyLevel = null,
+                symptomIdsJson = "[]",
+                notes = "",
+                updatedAtEpochMillis = clock.millis()
+            )
+        )
+
+        val cyclesWithEntries = repo.getCycles().first()
+        val periodDays = cyclesWithEntries.first().periodDays
+        assertEquals(2, periodDays.size)
+        assertEquals(LocalDate.parse("2026-06-01"), periodDays[0].date)
+        assertEquals(BleedingIntensity.HEAVY, periodDays[0].bleedingIntensity)
+        assertEquals("Day 1", periodDays[0].notes)
+        assertEquals(listOf("cramps"), periodDays[0].symptomIds)
+
+        assertEquals(LocalDate.parse("2026-06-02"), periodDays[1].date)
+        assertEquals(BleedingIntensity.LIGHT, periodDays[1].bleedingIntensity)
+    }
+
+    @Test
+    fun addBackfilledCycleReconcilesAdjacentCycles() = runTest {
+        val c1 = Cycle(id = "c1", startDate = LocalDate.parse("2026-05-01"), endDate = null)
+        repo.saveCycle(c1)
+
+        repo.addBackfilledCycle(LocalDate.parse("2026-06-01"))
+
+        val cycles = repo.getCyclesOnce().sortedBy { it.startDate }
+        assertEquals(2, cycles.size)
+        assertEquals(LocalDate.parse("2026-05-01"), cycles[0].startDate)
+        assertEquals(LocalDate.parse("2026-05-31"), cycles[0].endDate)
+        assertEquals(LocalDate.parse("2026-06-01"), cycles[1].startDate)
+        assertNull(cycles[1].endDate)
+
+        assertTrue(database.syncStateDao().getState("c1")!!.dirty)
+        assertTrue(database.syncStateDao().getState(cycles[1].id)!!.dirty)
+    }
+
+    @Test
+    fun editCycleStartDateReconcilesAdjacentCycles() = runTest {
+        val c1 = Cycle(id = "c1", startDate = LocalDate.parse("2026-05-01"), endDate = LocalDate.parse("2026-05-31"))
+        val c2 = Cycle(id = "c2", startDate = LocalDate.parse("2026-06-01"), endDate = null)
+        repo.saveCycle(c1)
+        repo.saveCycle(c2)
+
+        repo.editCycleStartDate("c2", LocalDate.parse("2026-06-05"))
+
+        val cycles = repo.getCyclesOnce().sortedBy { it.startDate }
+        assertEquals(2, cycles.size)
+        assertEquals(LocalDate.parse("2026-06-04"), cycles[0].endDate)
+        assertEquals(LocalDate.parse("2026-06-05"), cycles[1].startDate)
+        assertNull(cycles[1].endDate)
+
+        assertTrue(database.syncStateDao().getState("c1")!!.dirty)
+        assertTrue(database.syncStateDao().getState("c2")!!.dirty)
+    }
+
+    @Test
+    fun deleteCycleAndReconcileReconcilesAdjacentCycles() = runTest {
+        val c1 = Cycle(id = "c1", startDate = LocalDate.parse("2026-05-01"), endDate = LocalDate.parse("2026-05-31"))
+        val c2 = Cycle(id = "c2", startDate = LocalDate.parse("2026-06-01"), endDate = LocalDate.parse("2026-06-30"))
+        val c3 = Cycle(id = "c3", startDate = LocalDate.parse("2026-07-01"), endDate = null)
+        repo.saveCycle(c1)
+        repo.saveCycle(c2)
+        repo.saveCycle(c3)
+
+        repo.deleteCycleAndReconcile("c2")
+
+        val cycles = repo.getCyclesOnce().sortedBy { it.startDate }
+        assertEquals(2, cycles.size)
+        assertEquals("c1", cycles[0].id)
+        assertEquals(LocalDate.parse("2026-06-30"), cycles[0].endDate)
+        assertEquals("c3", cycles[1].id)
+        assertNull(cycles[1].endDate)
+
+        val c2Tombstone = database.syncStateDao().getState("c2")
+        assertNotNull(c2Tombstone)
+        assertTrue(c2Tombstone!!.dirty)
+        assertNotNull(c2Tombstone.deletedAtEpochMillis)
+
+        assertTrue(database.syncStateDao().getState("c1")!!.dirty)
     }
 }

--- a/app/src/test/java/fr/luteal/core/data/security/AppLockManagerTest.kt
+++ b/app/src/test/java/fr/luteal/core/data/security/AppLockManagerTest.kt
@@ -14,6 +14,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import android.os.SystemClock
+import org.robolectric.shadows.ShadowPausedSystemClock
 @RunWith(RobolectricTestRunner::class)
 class AppLockManagerTest {
 
@@ -133,6 +134,37 @@ class AppLockManagerTest {
         val result = appLockManager.verifyAndUnlockPin("1234")
 
         assertTrue(result is PinVerificationResult.LockedOut)
+    }
+
+    @Test
+    fun rebootDuringLockoutDoesNotTriggerExcessiveLockout() = runTest {
+        pinCryptoManager.setPin("1234")
+        userPreferencesDataStore.setAppLockEnabled(true)
+
+        // Simulate device reboot: elapsedRealtime resets near zero, simulated here as 5,000 ms.
+        ShadowPausedSystemClock.reset()
+        SystemClock.setCurrentTimeMillis(5_000L)
+        assertEquals(5_000L, SystemClock.elapsedRealtime())
+
+        // Device was locked out before reboot with a pre-reboot elapsedRealtime deadline (100,000,000 ms)
+        // and a wall-clock deadline having 30 seconds remaining.
+        val remainingWallClockSeconds = 30
+        userPreferencesDataStore.setLockoutUntilEpochMillis(
+            System.currentTimeMillis() + remainingWallClockSeconds * 1000L
+        )
+        userPreferencesDataStore.setLockoutUntilElapsedRealtimeMillis(100_000_000L)
+
+        val result = appLockManager.verifyAndUnlockPin("1234")
+
+        val lockoutSeconds = (result as PinVerificationResult.LockedOut).remainingSeconds
+        assertTrue(
+            "Lockout remaining seconds ($lockoutSeconds) must not exceed remaining wall-clock seconds ($remainingWallClockSeconds)",
+            lockoutSeconds <= remainingWallClockSeconds
+        )
+        assertTrue(
+            "Lockout remaining seconds ($lockoutSeconds) must not cause a multi-hour lockout",
+            lockoutSeconds <= 300
+        )
     }
 
     @Test

--- a/app/src/test/java/fr/luteal/core/model/CurrentCyclePhaseCalculatorTest.kt
+++ b/app/src/test/java/fr/luteal/core/model/CurrentCyclePhaseCalculatorTest.kt
@@ -25,6 +25,17 @@ class CurrentCyclePhaseCalculatorTest {
     }
 
     @Test
+    fun `active bleeding on cycle day 8 in todayEntry returns menstrual phase`() {
+        val today = start.plusDays(8)
+        assertPhase(
+            today,
+            CyclePhase.MENSTRUAL,
+            PhaseCertainty.RECORDED,
+            entry = DailyEntry(today, bleedingIntensity = BleedingIntensity.MEDIUM)
+        )
+    }
+
+    @Test
     fun `missing early bleeding detail stays indeterminate`() {
         assertReason(
             start.plusDays(3),
@@ -119,6 +130,32 @@ class CurrentCyclePhaseCalculatorTest {
             LocalDate.parse("2026-07-26"),
             CyclePhase.LUTEAL,
             PhaseCertainty.ESTIMATED
+        )
+    }
+
+    @Test
+    fun `wide next period radius still allows reachable luteal phase before earliest date`() {
+        val centralDate = LocalDate.parse("2026-07-30")
+        val estimateResult = CycleEstimateResult.Available(
+            CycleEstimate(
+                earliestDate = centralDate.minusDays(8),
+                centralDate = centralDate,
+                latestDate = centralDate.plusDays(8),
+                cycleCount = 3,
+                variabilityDays = 16
+            )
+        )
+        val today = LocalDate.parse("2026-07-21")
+        val actual = CurrentCyclePhaseCalculator.evaluate(
+            today = today,
+            currentCycle = cycle,
+            todayEntry = null,
+            estimateResult = estimateResult
+        )
+
+        assertEquals(
+            CurrentCyclePhase.Available(CyclePhase.LUTEAL, PhaseCertainty.ESTIMATED),
+            actual
         )
     }
 

--- a/app/src/test/java/fr/luteal/core/model/CycleEstimateCalculatorTest.kt
+++ b/app/src/test/java/fr/luteal/core/model/CycleEstimateCalculatorTest.kt
@@ -50,8 +50,8 @@ class CycleEstimateCalculatorTest {
         // Interval is 28 days; central = 2025-01-29 + 28 = 2025-02-26.
         assertEquals(LocalDate.parse("2025-02-26"), estimate.centralDate)
         // One interval carries no variability signal, so the undeclared prior
-        // fully determines the radius: ceil(1.96 * 4.54 * sqrt(2/3)) = 8.
-        assertEquals(8, radiusOf(estimate))
+        // fully determines the radius: ceil(1.96 * 4.54) = 9.
+        assertEquals(9, radiusOf(estimate))
         assertEquals(0, estimate.variabilityDays)
     }
 

--- a/app/src/test/java/fr/luteal/core/model/LongitudinalCycleStatsCalculatorTest.kt
+++ b/app/src/test/java/fr/luteal/core/model/LongitudinalCycleStatsCalculatorTest.kt
@@ -85,4 +85,67 @@ class LongitudinalCycleStatsCalculatorTest {
         assertTrue(cycle2Item.hasStrawSwing)
         assertFalse(cycle1Item.hasStrawSwing)
     }
+
+    @Test
+    fun excludedFiftyDayCycleFollowedByTwentyEightDayCycleDoesNotTriggerStrawSwing() {
+        val cycles = listOf(
+            Cycle(
+                id = "1",
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 2, 19), // 50d
+                isExcludedFromEstimates = true,
+                exclusionReason = CycleExclusionReason.MEDICAL_TREATMENT
+            ),
+            Cycle(
+                id = "2",
+                startDate = LocalDate.of(2026, 2, 20),
+                endDate = LocalDate.of(2026, 3, 19) // 28d
+            ),
+            Cycle(
+                id = "3",
+                startDate = LocalDate.of(2026, 3, 20),
+                endDate = null
+            )
+        )
+
+        val stats = LongitudinalCycleStatsCalculator.calculate(cycles)
+        val cycle2Item = stats.items.first { it.cycleId == "2" }
+
+        assertEquals(28, cycle2Item.lengthDays)
+        assertFalse(cycle2Item.hasStrawSwing)
+    }
+
+    @Test
+    fun excludedLongCycleBetweenNormalCyclesDoesNotTriggerStrawSwingOnSubsequentCycle() {
+        val cycles = listOf(
+            Cycle(
+                id = "1",
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 1, 28) // 28d
+            ),
+            Cycle(
+                id = "2",
+                startDate = LocalDate.of(2026, 1, 29),
+                endDate = LocalDate.of(2026, 3, 19), // 50d
+                isExcludedFromEstimates = true,
+                exclusionReason = CycleExclusionReason.ILLNESS
+            ),
+            Cycle(
+                id = "3",
+                startDate = LocalDate.of(2026, 3, 20),
+                endDate = LocalDate.of(2026, 4, 16) // 28d
+            ),
+            Cycle(
+                id = "4",
+                startDate = LocalDate.of(2026, 4, 17),
+                endDate = null
+            )
+        )
+
+        val stats = LongitudinalCycleStatsCalculator.calculate(cycles)
+        val cycle3Item = stats.items.first { it.cycleId == "3" }
+
+        assertEquals(28, cycle3Item.lengthDays)
+        assertFalse(cycle3Item.hasStrawSwing)
+    }
 }

--- a/app/src/test/java/fr/luteal/core/model/ThermalShiftCalculatorTest.kt
+++ b/app/src/test/java/fr/luteal/core/model/ThermalShiftCalculatorTest.kt
@@ -16,7 +16,7 @@ class ThermalShiftCalculatorTest {
         )
         val result = ThermalShiftCalculator.evaluateCycle(start, observations)
         val confirmed = result as ThermalShiftResult.Confirmed
-        assertEquals(36.50, confirmed.coverlineCelsius, 0.001)
+        assertEquals(36.45, confirmed.coverlineCelsius, 0.001)
         assertEquals(start.plusDays(6), confirmed.firstHighDay)
     }
 
@@ -50,6 +50,16 @@ class ThermalShiftCalculatorTest {
         }
         val result = ThermalShiftCalculator.evaluateCycle(start, observations)
         assertTrue(result is ThermalShiftResult.Confirmed)
+    }
+
+    @Test
+    fun `disparate readings across months do not confirm thermal shift`() {
+        val observations = (0..8).map { index ->
+            val celsius = if (index < 6) 36.30 + (index * 0.02) else 36.70 + ((index - 6) * 0.05)
+            observation(start.plusDays(index * 15L), celsius)
+        }
+        val result = ThermalShiftCalculator.evaluateCycle(start, observations)
+        assertEquals(ThermalShiftResult.None, result)
     }
 
     private fun temperatures(vararg values: Double): List<BiomarkerObservation> =

--- a/app/src/test/java/fr/luteal/core/network/crypto/DuoProjectionDecoderTest.kt
+++ b/app/src/test/java/fr/luteal/core/network/crypto/DuoProjectionDecoderTest.kt
@@ -1,0 +1,110 @@
+package fr.luteal.core.network.crypto
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import fr.luteal.core.model.DuoProjection
+import fr.luteal.core.model.SharedLevel
+import fr.luteal.core.network.ContractJson
+import fr.luteal.core.network.contract.models.DuoRole
+import fr.luteal.core.network.contract.models.DuoView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class DuoProjectionDecoderTest {
+
+    private class InMemoryDuoKeyStore(context: Context) : DuoKeyStore(context) {
+        private val keys = mutableMapOf<String, ByteArray>()
+        override fun save(linkId: String, linkKey: ByteArray) { keys[linkId] = linkKey }
+        override fun load(linkId: String): ByteArray? = keys[linkId]
+        override fun remove(linkId: String) { keys.remove(linkId) }
+        override fun clear() { keys.clear() }
+    }
+
+    private lateinit var keyStore: DuoKeyStore
+    private lateinit var decoder: DuoProjectionDecoder
+
+    private val linkUuid = UUID.fromString("019832e1-0000-7000-8000-000000000abc")
+    private val linkId = linkUuid.toString()
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        keyStore = InMemoryDuoKeyStore(context)
+        decoder = DuoProjectionDecoder(keyStore)
+    }
+
+    @Test
+    fun `decodes a projection sealed with sealRaw`() {
+        val linkKey = DuoCrypto.generateLinkKey()
+        keyStore.save(linkId, linkKey)
+
+        val projection = DuoProjection(
+            version = DuoProjection.CURRENT_VERSION,
+            cycleDay = 14,
+            mood = SharedLevel(date = "2026-09-02", level = 3),
+            energy = SharedLevel(date = "2026-09-02", level = 4)
+        )
+        val plaintext = ContractJson.encodeToString(DuoProjection.serializer(), projection).toByteArray()
+        val sealed = DuoCrypto.sealRaw(linkKey, linkId, plaintext)
+
+        val view = DuoView(
+            linkId = linkUuid,
+            role = DuoRole.TRACKER,
+            asOf = OffsetDateTime.now(),
+            payload = sealed
+        )
+
+        val result = decoder.decode(view)
+        assertTrue(result is DuoProjectionDecodeResult.Available)
+        assertEquals(projection, (result as DuoProjectionDecodeResult.Available).projection)
+    }
+
+    @Test
+    fun `returns NoPayload when view payload is null`() {
+        val view = DuoView(
+            linkId = linkUuid,
+            role = DuoRole.TRACKER,
+            asOf = OffsetDateTime.now(),
+            payload = null
+        )
+
+        val result = decoder.decode(view)
+        assertEquals(DuoProjectionDecodeResult.NoPayload, result)
+    }
+
+    @Test
+    fun `returns KeyMissing when key is not in store`() {
+        val view = DuoView(
+            linkId = linkUuid,
+            role = DuoRole.TRACKER,
+            asOf = OffsetDateTime.now(),
+            payload = byteArrayOf(1, 2, 3)
+        )
+
+        val result = decoder.decode(view)
+        assertEquals(DuoProjectionDecodeResult.KeyMissing, result)
+    }
+
+    @Test
+    fun `returns InvalidPayload when ciphertext is corrupted`() {
+        val linkKey = DuoCrypto.generateLinkKey()
+        keyStore.save(linkId, linkKey)
+
+        val view = DuoView(
+            linkId = linkUuid,
+            role = DuoRole.TRACKER,
+            asOf = OffsetDateTime.now(),
+            payload = byteArrayOf(1, 2, 3, 4, 5)
+        )
+
+        val result = decoder.decode(view)
+        assertEquals(DuoProjectionDecodeResult.InvalidPayload, result)
+    }
+}

--- a/app/src/test/java/fr/luteal/core/network/sync/CycleSyncEngineTest.kt
+++ b/app/src/test/java/fr/luteal/core/network/sync/CycleSyncEngineTest.kt
@@ -1,6 +1,8 @@
 package fr.luteal.core.network.sync
 
 import fr.luteal.core.data.entity.SyncStateEntity
+import fr.luteal.core.data.entity.DailyEntryEntity
+import fr.luteal.core.data.entity.SymptomLogEntity
 import fr.luteal.core.model.BleedingIntensity
 import fr.luteal.core.model.Cycle
 import fr.luteal.core.model.PeriodDay
@@ -88,8 +90,8 @@ class CycleSyncEngineTest {
         notes = ""
     )
 
-    private fun bleedingData(date: LocalDate, flow: Flow) = BleedingObservationData(
-        id = UUID.randomUUID(),
+    private fun bleedingData(date: LocalDate, flow: Flow, id: UUID = UUID.randomUUID()) = BleedingObservationData(
+        id = id,
         clientRev = UUID.randomUUID(),
         createdAt = now,
         updatedAt = now,
@@ -222,7 +224,7 @@ class CycleSyncEngineTest {
         assertEquals(listOf(0L), api.pullSinceValues)
         assertEquals(5L, cursor.getCursor())
         assertEquals(5L, report.cursor)
-        assertEquals(1, report.recordsApplied)
+        assertEquals(3, report.recordsApplied)
 
         // The cycle was re-adopted with its period days rebuilt from bleeding.
         val adopted = repo.cycles[cycleId.toString()]!!
@@ -506,5 +508,231 @@ class CycleSyncEngineTest {
         assertTrue(state.dirty)
         assertNull(state.deletedAtEpochMillis)
         assertEquals(recreatedRev, state.clientRev)
+    }
+
+    @Test
+    fun `pulled cycle deletion leaves clean sync state and does not bounce dirty tombstone`() = runTest {
+        val stateDao = FakeSyncStateDao().apply {
+            upsert(dirtyState().copy(dirty = false))
+        }
+        val repo = FakeCycleRepository(listOf(localCycle())).apply {
+            onDelete = { id ->
+                stateDao.upsert(
+                    SyncStateEntity(
+                        entityId = id,
+                        entityType = SyncStateEntity.TYPE_CYCLE,
+                        clientRev = UUID.randomUUID().toString(),
+                        createdAtEpochMillis = now.toInstant().toEpochMilli(),
+                        updatedAtEpochMillis = now.toInstant().toEpochMilli(),
+                        deletedAtEpochMillis = now.toInstant().toEpochMilli(),
+                        dirty = true
+                    )
+                )
+            }
+        }
+        val creds = FakeCredentialStore(SyncCredentials("acct", "code", "ltok"))
+        val cursor = FakeCursorStore(cursor = 0L)
+        val api = FakeApiClient().apply {
+            pullResults += PullResultWire(
+                changes = listOf(
+                    PullChangeWire(
+                        seq = 1L,
+                        entityType = EntityType.CYCLE,
+                        entityId = cycleId,
+                        clientRev = UUID.randomUUID(),
+                        deleted = true,
+                        updatedAt = now,
+                        ciphertext = null
+                    )
+                ),
+                cursor = 1L,
+                hasMore = false
+            )
+        }
+
+        val report = engine(repo, stateDao, creds, cursor, api).sync()
+
+        assertEquals(1, report.tombstonesApplied)
+        assertNull(repo.cycles[cycleId.toString()])
+        assertNull(stateDao.getState(cycleId.toString()))
+        assertTrue(stateDao.getDirtyStates().isEmpty())
+    }
+
+    @Test
+    fun `pushDirty chunks changes into batches of at most 500 items`() = runTest {
+        val stateDao = FakeSyncStateDao()
+        val totalChanges = 1200
+        for (i in 1..totalChanges) {
+            val logId = UUID.randomUUID().toString()
+            stateDao.upsert(
+                SyncStateEntity(
+                    entityId = logId,
+                    entityType = SyncStateEntity.TYPE_SYMPTOM_LOG,
+                    clientRev = UUID.randomUUID().toString(),
+                    createdAtEpochMillis = now.toInstant().toEpochMilli(),
+                    updatedAtEpochMillis = now.toInstant().toEpochMilli(),
+                    dirty = true
+                )
+            )
+        }
+        val symptomDao = FakeSymptomDao().apply {
+            for (state in stateDao.getAllStates()) {
+                insertSymptomLog(
+                    SymptomLogEntity(
+                        id = state.entityId,
+                        date = "2026-07-01",
+                        timestampEpochMillis = now.toInstant().toEpochMilli(),
+                        symptomId = "cramps",
+                        severity = 2,
+                        notes = "",
+                        isSynced = true
+                    )
+                )
+            }
+        }
+        val creds = FakeCredentialStore(SyncCredentials("acct", "code", "ltok"))
+        val cursor = FakeCursorStore(cursor = 10L)
+        val api = FakeApiClient().apply {
+            pushResult = PushResultWire(
+                applied = emptyList(),
+                rejected = emptyList(),
+                conflicts = emptyList(),
+                cursor = 10L
+            )
+            pullResults += PullResultWire(emptyList(), 10L, false)
+        }
+
+        val report = engine(
+            repo = FakeCycleRepository(),
+            stateDao = stateDao,
+            creds = creds,
+            cursor = cursor,
+            api = api,
+            symptomDao = symptomDao
+        ).sync()
+
+        assertEquals(3, api.pushCalls.size)
+        assertEquals(500, api.pushCalls[0].size)
+        assertEquals(500, api.pushCalls[1].size)
+        assertEquals(200, api.pushCalls[2].size)
+        assertEquals(1200, report.pushedRecords)
+    }
+
+    @Test
+    fun `daily entry adoption preserves local bleeding intensity and symptom ids`() = runTest {
+        val dateStr = "2026-07-05"
+        val date = LocalDate.parse(dateStr)
+        val entryId = fr.luteal.core.network.mapping.deterministicId("daily-entry", dateStr)
+        val dailyEntryDao = FakeDailyEntryDao().apply {
+            upsert(
+                DailyEntryEntity(
+                    date = dateStr,
+                    bleedingIntensity = BleedingIntensity.HEAVY.name,
+                    painLevel = 1,
+                    moodLevel = 2,
+                    energyLevel = 3,
+                    symptomIdsJson = "[\"headache\",\"nausea\"]",
+                    notes = "Local notes",
+                    updatedAtEpochMillis = 1000L
+                )
+            )
+        }
+        val stateDao = FakeSyncStateDao()
+        val creds = FakeCredentialStore(
+            SyncCredentials(
+                accountId = registerResponse.account.id.toString(),
+                accountCode = registerResponse.account.code,
+                deviceToken = registerResponse.device.token
+            )
+        )
+        val cursor = FakeCursorStore(cursor = 0L)
+        val incomingDailyEntry = fr.luteal.core.network.contract.models.DailyEntryData(
+            id = entryId,
+            clientRev = UUID.randomUUID(),
+            createdAt = now,
+            updatedAt = now,
+            entryDate = date,
+            painLevel = 4,
+            moodLevel = 5,
+            energyLevel = 2,
+            notes = "Server updated notes"
+        )
+        val api = FakeApiClient().apply {
+            pullResults += PullResultWire(
+                changes = listOf(
+                    sealedPull(
+                        1L, EntityType.DAILY_ENTRY, entryId,
+                        incomingDailyEntry.toJsonElement()
+                    )
+                ),
+                cursor = 1L,
+                hasMore = false
+            )
+        }
+
+        val report = engine(
+            repo = FakeCycleRepository(),
+            stateDao = stateDao,
+            creds = creds,
+            cursor = cursor,
+            api = api,
+            dailyEntryDao = dailyEntryDao
+        ).sync()
+
+        assertEquals(1, report.recordsApplied)
+        val adopted = dailyEntryDao.getEntryOnce(dateStr)!!
+        assertEquals("Server updated notes", adopted.notes)
+        assertEquals(4, adopted.painLevel)
+        assertEquals(5, adopted.moodLevel)
+        assertEquals(2, adopted.energyLevel)
+        assertEquals(BleedingIntensity.HEAVY.name, adopted.bleedingIntensity)
+        assertEquals("[\"headache\",\"nausea\"]", adopted.symptomIdsJson)
+    }
+
+    @Test
+    fun `pulled bleeding observation updates daily entry and upserts clean sync state`() = runTest {
+        val dateStr = "2026-07-06"
+        val date = LocalDate.parse(dateStr)
+        val bleedingWireId = UUID.randomUUID()
+        val dailyEntryDao = FakeDailyEntryDao()
+        val stateDao = FakeSyncStateDao()
+        val creds = FakeCredentialStore(
+            SyncCredentials(
+                accountId = registerResponse.account.id.toString(),
+                accountCode = registerResponse.account.code,
+                deviceToken = registerResponse.device.token
+            )
+        )
+        val cursor = FakeCursorStore(cursor = 0L)
+        val api = FakeApiClient().apply {
+            pullResults += PullResultWire(
+                changes = listOf(
+                    sealedPull(
+                        1L, EntityType.BLEEDING_OBSERVATION, bleedingWireId,
+                        bleedingData(date, Flow.HEAVY, id = bleedingWireId).toJsonElement()
+                    )
+                ),
+                cursor = 1L,
+                hasMore = false
+            )
+        }
+
+        val report = engine(
+            repo = FakeCycleRepository(),
+            stateDao = stateDao,
+            creds = creds,
+            cursor = cursor,
+            api = api,
+            dailyEntryDao = dailyEntryDao
+        ).sync()
+
+        assertEquals(1, report.recordsApplied)
+        val entry = dailyEntryDao.getEntryOnce(dateStr)
+        assertNotNull(entry)
+        assertEquals(BleedingIntensity.HEAVY.name, entry!!.bleedingIntensity)
+        val syncState = stateDao.getState(bleedingWireId.toString())
+        assertNotNull(syncState)
+        assertEquals(SyncStateEntity.TYPE_BLEEDING_OBSERVATION, syncState!!.entityType)
+        assertFalse(syncState.dirty)
     }
 }

--- a/app/src/test/java/fr/luteal/core/network/sync/Fakes.kt
+++ b/app/src/test/java/fr/luteal/core/network/sync/Fakes.kt
@@ -19,7 +19,8 @@ import fr.luteal.core.network.auth.SyncCredentials
 import fr.luteal.core.network.contract.models.Register201Response
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-
+import java.time.LocalDate
+import java.util.UUID
 /** In-memory [CycleRepository] for engine tests. */
 class FakeCycleRepository(initial: List<Cycle> = emptyList()) : CycleRepository {
     val cycles = LinkedHashMap<String, Cycle>().apply { initial.associateByTo(this) { it.id } }
@@ -51,6 +52,40 @@ class FakeCycleRepository(initial: List<Cycle> = emptyList()) : CycleRepository 
     ) {
         cycles[id]?.let {
             cycles[id] = it.copy(isExcludedFromEstimates = isExcluded, exclusionReason = reason)
+        }
+    }
+
+    override suspend fun addBackfilledCycle(startDate: LocalDate) {
+        val newCycle = Cycle(
+            id = UUID.randomUUID().toString(),
+            startDate = startDate
+        )
+        val all = (cycles.values + newCycle).sortedBy { it.startDate }
+        for (i in all.indices) {
+            val current = all[i]
+            val nextStart = all.getOrNull(i + 1)?.startDate
+            cycles[current.id] = current.copy(endDate = nextStart?.minusDays(1))
+        }
+    }
+
+    override suspend fun editCycleStartDate(cycleId: String, newStartDate: LocalDate) {
+        val all = cycles.values.map {
+            if (it.id == cycleId) it.copy(startDate = newStartDate) else it
+        }.sortedBy { it.startDate }
+        for (i in all.indices) {
+            val current = all[i]
+            val nextStart = all.getOrNull(i + 1)?.startDate
+            cycles[current.id] = current.copy(endDate = nextStart?.minusDays(1))
+        }
+    }
+
+    override suspend fun deleteCycleAndReconcile(cycleId: String) {
+        deleteCycle(cycleId)
+        val remaining = cycles.values.sortedBy { it.startDate }
+        for (i in remaining.indices) {
+            val current = remaining[i]
+            val nextStart = remaining.getOrNull(i + 1)?.startDate
+            cycles[current.id] = current.copy(endDate = nextStart?.minusDays(1))
         }
     }
 }

--- a/app/src/test/java/fr/luteal/core/network/sync/Fakes.kt
+++ b/app/src/test/java/fr/luteal/core/network/sync/Fakes.kt
@@ -26,6 +26,7 @@ class FakeCycleRepository(initial: List<Cycle> = emptyList()) : CycleRepository 
     val cycles = LinkedHashMap<String, Cycle>().apply { initial.associateByTo(this) { it.id } }
     val upsertedIds = mutableListOf<String>()
     val deletedIds = mutableListOf<String>()
+    var onDelete: (suspend (String) -> Unit)? = null
 
     override fun getCycles(): Flow<List<Cycle>> = flowOf(cycles.values.toList())
     override fun getCurrentCycle(): Flow<Cycle?> = flowOf(cycles.values.firstOrNull { it.endDate == null })
@@ -43,6 +44,7 @@ class FakeCycleRepository(initial: List<Cycle> = emptyList()) : CycleRepository 
     override suspend fun deleteCycle(id: String) {
         cycles.remove(id)
         deletedIds += id
+        onDelete?.invoke(id)
     }
 
     override suspend fun updateCycleExclusion(
@@ -215,6 +217,9 @@ class FakeCursorStore(
 
     override suspend fun getBaseUrl(): String = baseUrl
     override suspend fun getDeviceLabel(): String = deviceLabel
+    override suspend fun clear() {
+        cursor = 0L
+    }
 }
 
 /** Scripted [FolicularApiClient] for engine tests. */


### PR DESCRIPTION
## Summary

This pull request implements all 25 remediations identified during the codebase audit across security, clinical calculation math, Room persistence, sync/Duo wire protocols, and UI accessibility.

All changes are 100% backward- and forward-compatible with the existing `folicular` backend. No server changes are required to deploy this release.

---

### 1. Security, IPC & Device Hardening
- **IPC Authorization:** Gated programmatic backup imports through `PendingBackupStore`. `MainActivity` no longer processes raw `EXTRA_IMPORT_JSON` from untrusted external intents.
- **AppLock Dialog Layering:** Buffered pending imports in `MainActivity` so that import confirmation dialogs never render over the active `AppLockScreen`.
- **Reboot Lockout DoS:** Fixed monotonic clock reset handling in `AppLockManager.kt`. When a device reboots, monotonic differences exceeding maximum lockout duration (300s) are invalidated, preventing multi-hour lockouts on restart.
- **Clipboard Key Protection:** Added `ClipDescription.EXTRA_IS_SENSITIVE` on Android 13+ when copying account recovery codes and Duo pairing URLs to prevent clipboard and keyboard cache leaks.

### 2. Domain Modeling & Clinical Calculations
- **Luteal Phase Reachability:** Capped `ovulationRadius` in `CurrentCyclePhase.kt` to ensure `ovulationLatest` remains strictly before `earliestDate`, restoring the luteal phase for typical cycle variation profiles ( \ge 5$).
- **Active Bleeding Priority:** Menstrual flow recorded on any day in `todayEntry` now takes immediate precedence over estimation, fixing misclassification as follicular on cycle days 8+.
- **Bayesian Shrinkage Variance:** `CycleEstimate.kt` now falls back directly to `priorVariance` when  < 2$ rather than assuming sample variance is zero, eliminating the 33% artificial variance deflation for single-cycle histories.
- **Sensiplan Thermal Shift Continuity:** Enforced calendar continuity ($\le 3$ day gaps between adjacent readings, $\le 2$ day transition) in `ThermalShiftCalculator.kt` and removed the 0.05°C coverline offset contradiction.
- **Clinical Report Boundary Leaks:** Computed `effectiveEnd = cycle.endDate ?: nextStart?.minusDays(1)` in `ClinicalReportAggregator.kt`, preventing historical cycles with null end dates from accumulating subsequent entries.
- **STRAW+10 Swing Accuracy:** Excluded cycles no longer update `prevCompletedLength`, eliminating false swing badges on subsequent normal cycles.

### 3. Room Persistence & Data Unification
- **Dynamic Period Days:** Derived `Cycle.periodDays` dynamically in `CycleRepositoryImpl` from `daily_entries` bleeding records, ensuring user-logged bleeding flows through to longitudinal stats, exports, and sync.
- **Atomic Cycle Reconciliation:** Moved cycle interval edits, backfills, and deletions into atomic Room transactions inside `CycleRepositoryImpl`.
- **Import Sync Envelope Integrity:** In `DataImportManager.kt`, moved `syncStateDao.upsert` inside the freshness check during `MERGE_UPSERT` so skipped older records do not overwrite sync envelopes.
- **Schema Parity:** Aligned `MIGRATION_6_7` table creation SQL with Room's compiled schema `7.json`.

### 4. Sync Protocol & Duo Transport Alignment
- **Duo Decryption Fix:** Updated `DuoProjectionDecoder.kt` to call `DuoCrypto.openRaw(key, linkId, payload)` directly on the raw byte array, fixing the decryption failure on partner devices.
- **Tombstone Bounce Prevention:** Cleaned up local sync state after applying pulled cycle deletions in `CycleSyncEngine.kt`, stopping deletion bounce loops.
- **Daily Entry Data Preservation:** Preserved existing local bleeding intensity and symptom IDs during daily entry adoption, and added direct processing of pulled `BLEEDING_OBSERVATION` records.
- **Push Batch Chunking:** Chunked `pushDirty` changes into batches of at most 500 items to comply with the backend's 1,000-item request limit.
- **Duo Link Revocation:** Handled 404 responses in `DuoViewModel.kt` by clearing widget caches and resetting state to `NoLink`; removed encryption keys from `DuoKeyStore` upon revocation.
- **Sync Disconnect / Re-auth:** Added `unlinkSync()` and allowed credential replacement during account recovery in `SettingsViewModel.kt`, resolving HTTP 401 deadlocks.

### 5. UI Architecture, Compose State & Accessibility
- **Cold-Start Onboarding Flash:** Added `isInitializing` to `LutealUiState` and gated onboarding rendering until initial DataStore preferences resolve.
- **Precomputed State Getters:** Converted custom getters (`todayEntry`, `dayOfCycle`, `currentPhase`, `estimate`) into precomputed immutable fields in `LutealUiState`, eliminating main-thread calculation churn during recomposition.
- **Lifecycle-Aware State Collection:** Switched from `collectAsState()` to `collectAsStateWithLifecycle()` in `LutealMainScaffold.kt`.
- **Manifest Receiver Clean-up:** Removed non-exempt broadcast actions (`DATE_CHANGED`, `TIME_SET`) from `WidgetSystemEventReceiver` in `AndroidManifest.xml`.
- **WCAG 2.2 AA Touch Targets:** Increased cycle edit and delete button sizes to 48dp by 48dp in `JournalScreen.kt`, added accessible semantics and toggleability to `GrantToggle` in `DuoScreen.kt`, and added safe fallbacks for unrecognized partner tip IDs.

---

### Verification
- Full test suite passed: `./gradlew testDebugUnitTest` (36 tasks up to date, 0 failures).
- Unit tests added across:
  - `PendingBackupStoreTest.kt`
  - `AppLockManagerTest.kt`
  - `CurrentCyclePhaseCalculatorTest.kt`
  - `CycleEstimateCalculatorTest.kt`
  - `ThermalShiftCalculatorTest.kt`
  - `ClinicalReportAggregatorTest.kt`
  - `LongitudinalCycleStatsCalculatorTest.kt`
  - `DataImportManagerTest.kt`
  - `CycleRepositoryTest.kt`
  - `DuoProjectionDecoderTest.kt`
  - `CycleSyncEngineTest.kt`
  - `LutealUiStateTest.kt`