### PR TITLE
fix: address quality audit findings in lint, migrations, sync, and reports

### DIFF
--- a/app/schemas/fr.luteal.core.data.local.LutealDatabase/1.json
+++ b/app/schemas/fr.luteal.core.data.local.LutealDatabase/1.json
@@ -1,0 +1,202 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "074ea202ffa76e691470943ebbf074b6",
+    "entities": [
+      {
+        "tableName": "cycles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT, `periodDaysJson` TEXT NOT NULL, `averageLengthDays` INTEGER NOT NULL, `lutealPhaseLengthDays` INTEGER NOT NULL, `isSynced` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "periodDaysJson",
+            "columnName": "periodDaysJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "averageLengthDays",
+            "columnName": "averageLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lutealPhaseLengthDays",
+            "columnName": "lutealPhaseLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "symptom_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `date` TEXT NOT NULL, `timestampEpochMillis` INTEGER NOT NULL, `symptomId` TEXT NOT NULL, `severity` INTEGER NOT NULL, `notes` TEXT NOT NULL, `isSynced` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampEpochMillis",
+            "columnName": "timestampEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symptomId",
+            "columnName": "symptomId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "severity",
+            "columnName": "severity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "disorder_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`disorderId` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `customNotes` TEXT NOT NULL, `alertPhaseDaysBefore` INTEGER NOT NULL, PRIMARY KEY(`disorderId`))",
+        "fields": [
+          {
+            "fieldPath": "disorderId",
+            "columnName": "disorderId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNotes",
+            "columnName": "customNotes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertPhaseDaysBefore",
+            "columnName": "alertPhaseDaysBefore",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "disorderId"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `role` TEXT NOT NULL, `syncMode` TEXT NOT NULL, `couplePairingCode` TEXT, `partnerName` TEXT, `isPaired` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncMode",
+            "columnName": "syncMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "couplePairingCode",
+            "columnName": "couplePairingCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "partnerName",
+            "columnName": "partnerName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaired",
+            "columnName": "isPaired",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '074ea202ffa76e691470943ebbf074b6')"
+    ]
+  }
+}

--- a/app/schemas/fr.luteal.core.data.local.LutealDatabase/2.json
+++ b/app/schemas/fr.luteal.core.data.local.LutealDatabase/2.json
@@ -1,0 +1,258 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "074ea202ffa76e691470943ebbf074b6",
+    "entities": [
+      {
+        "tableName": "cycles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT, `periodDaysJson` TEXT NOT NULL, `averageLengthDays` INTEGER NOT NULL, `lutealPhaseLengthDays` INTEGER NOT NULL, `isSynced` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "periodDaysJson",
+            "columnName": "periodDaysJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "averageLengthDays",
+            "columnName": "averageLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lutealPhaseLengthDays",
+            "columnName": "lutealPhaseLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "daily_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `bleedingIntensity` TEXT, `painLevel` INTEGER, `moodLevel` INTEGER, `energyLevel` INTEGER, `symptomIdsJson` TEXT NOT NULL, `notes` TEXT NOT NULL, `updatedAtEpochMillis` INTEGER NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bleedingIntensity",
+            "columnName": "bleedingIntensity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "painLevel",
+            "columnName": "painLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "moodLevel",
+            "columnName": "moodLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "energyLevel",
+            "columnName": "energyLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "symptomIdsJson",
+            "columnName": "symptomIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updatedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      },
+      {
+        "tableName": "symptom_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `date` TEXT NOT NULL, `timestampEpochMillis` INTEGER NOT NULL, `symptomId` TEXT NOT NULL, `severity` INTEGER NOT NULL, `notes` TEXT NOT NULL, `isSynced` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampEpochMillis",
+            "columnName": "timestampEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symptomId",
+            "columnName": "symptomId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "severity",
+            "columnName": "severity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "disorder_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`disorderId` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `customNotes` TEXT NOT NULL, `alertPhaseDaysBefore` INTEGER NOT NULL, PRIMARY KEY(`disorderId`))",
+        "fields": [
+          {
+            "fieldPath": "disorderId",
+            "columnName": "disorderId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNotes",
+            "columnName": "customNotes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertPhaseDaysBefore",
+            "columnName": "alertPhaseDaysBefore",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "disorderId"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `role` TEXT NOT NULL, `syncMode` TEXT NOT NULL, `couplePairingCode` TEXT, `partnerName` TEXT, `isPaired` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncMode",
+            "columnName": "syncMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "couplePairingCode",
+            "columnName": "couplePairingCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "partnerName",
+            "columnName": "partnerName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaired",
+            "columnName": "isPaired",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '074ea202ffa76e691470943ebbf074b6')"
+    ]
+  }
+}

--- a/app/schemas/fr.luteal.core.data.local.LutealDatabase/3.json
+++ b/app/schemas/fr.luteal.core.data.local.LutealDatabase/3.json
@@ -1,0 +1,315 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "074ea202ffa76e691470943ebbf074b6",
+    "entities": [
+      {
+        "tableName": "cycles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT, `periodDaysJson` TEXT NOT NULL, `averageLengthDays` INTEGER NOT NULL, `lutealPhaseLengthDays` INTEGER NOT NULL, `isSynced` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "periodDaysJson",
+            "columnName": "periodDaysJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "averageLengthDays",
+            "columnName": "averageLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lutealPhaseLengthDays",
+            "columnName": "lutealPhaseLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "daily_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `bleedingIntensity` TEXT, `painLevel` INTEGER, `moodLevel` INTEGER, `energyLevel` INTEGER, `symptomIdsJson` TEXT NOT NULL, `notes` TEXT NOT NULL, `updatedAtEpochMillis` INTEGER NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bleedingIntensity",
+            "columnName": "bleedingIntensity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "painLevel",
+            "columnName": "painLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "moodLevel",
+            "columnName": "moodLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "energyLevel",
+            "columnName": "energyLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "symptomIdsJson",
+            "columnName": "symptomIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updatedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      },
+      {
+        "tableName": "symptom_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `date` TEXT NOT NULL, `timestampEpochMillis` INTEGER NOT NULL, `symptomId` TEXT NOT NULL, `severity` INTEGER NOT NULL, `notes` TEXT NOT NULL, `isSynced` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampEpochMillis",
+            "columnName": "timestampEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symptomId",
+            "columnName": "symptomId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "severity",
+            "columnName": "severity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "disorder_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`disorderId` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `customNotes` TEXT NOT NULL, `alertPhaseDaysBefore` INTEGER NOT NULL, PRIMARY KEY(`disorderId`))",
+        "fields": [
+          {
+            "fieldPath": "disorderId",
+            "columnName": "disorderId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNotes",
+            "columnName": "customNotes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertPhaseDaysBefore",
+            "columnName": "alertPhaseDaysBefore",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "disorderId"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `role` TEXT NOT NULL, `syncMode` TEXT NOT NULL, `couplePairingCode` TEXT, `partnerName` TEXT, `isPaired` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncMode",
+            "columnName": "syncMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "couplePairingCode",
+            "columnName": "couplePairingCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "partnerName",
+            "columnName": "partnerName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaired",
+            "columnName": "isPaired",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      },
+      {
+        "tableName": "cycle_sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cycleId` TEXT NOT NULL, `clientRev` TEXT NOT NULL, `createdAtEpochMillis` INTEGER NOT NULL, `updatedAtEpochMillis` INTEGER NOT NULL, `deletedAtEpochMillis` INTEGER, `dirty` INTEGER NOT NULL DEFAULT 1, `lastPushError` TEXT, PRIMARY KEY(`cycleId`))",
+        "fields": [
+          {
+            "fieldPath": "cycleId",
+            "columnName": "cycleId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientRev",
+            "columnName": "clientRev",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtEpochMillis",
+            "columnName": "createdAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updatedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAtEpochMillis",
+            "columnName": "deletedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dirty",
+            "columnName": "dirty",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastPushError",
+            "columnName": "lastPushError",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cycleId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '074ea202ffa76e691470943ebbf074b6')"
+    ]
+  }
+}

--- a/app/schemas/fr.luteal.core.data.local.LutealDatabase/4.json
+++ b/app/schemas/fr.luteal.core.data.local.LutealDatabase/4.json
@@ -1,0 +1,316 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "074ea202ffa76e691470943ebbf074b6",
+    "entities": [
+      {
+        "tableName": "cycles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT, `periodDaysJson` TEXT NOT NULL, `averageLengthDays` INTEGER NOT NULL, `lutealPhaseLengthDays` INTEGER NOT NULL, `isSynced` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "periodDaysJson",
+            "columnName": "periodDaysJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "averageLengthDays",
+            "columnName": "averageLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lutealPhaseLengthDays",
+            "columnName": "lutealPhaseLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`entityId` TEXT NOT NULL, `entityType` TEXT NOT NULL, `clientRev` TEXT NOT NULL, `createdAtEpochMillis` INTEGER NOT NULL, `updatedAtEpochMillis` INTEGER NOT NULL, `deletedAtEpochMillis` INTEGER, `dirty` INTEGER NOT NULL, `lastPushError` TEXT, PRIMARY KEY(`entityId`))",
+        "fields": [
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientRev",
+            "columnName": "clientRev",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtEpochMillis",
+            "columnName": "createdAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updatedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAtEpochMillis",
+            "columnName": "deletedAtEpochMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dirty",
+            "columnName": "dirty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPushError",
+            "columnName": "lastPushError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "entityId"
+          ]
+        }
+      },
+      {
+        "tableName": "daily_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `bleedingIntensity` TEXT, `painLevel` INTEGER, `moodLevel` INTEGER, `energyLevel` INTEGER, `symptomIdsJson` TEXT NOT NULL, `notes` TEXT NOT NULL, `updatedAtEpochMillis` INTEGER NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bleedingIntensity",
+            "columnName": "bleedingIntensity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "painLevel",
+            "columnName": "painLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "moodLevel",
+            "columnName": "moodLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "energyLevel",
+            "columnName": "energyLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "symptomIdsJson",
+            "columnName": "symptomIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updatedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      },
+      {
+        "tableName": "symptom_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `date` TEXT NOT NULL, `timestampEpochMillis` INTEGER NOT NULL, `symptomId` TEXT NOT NULL, `severity` INTEGER NOT NULL, `notes` TEXT NOT NULL, `isSynced` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampEpochMillis",
+            "columnName": "timestampEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symptomId",
+            "columnName": "symptomId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "severity",
+            "columnName": "severity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "disorder_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`disorderId` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `customNotes` TEXT NOT NULL, `alertPhaseDaysBefore` INTEGER NOT NULL, PRIMARY KEY(`disorderId`))",
+        "fields": [
+          {
+            "fieldPath": "disorderId",
+            "columnName": "disorderId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNotes",
+            "columnName": "customNotes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertPhaseDaysBefore",
+            "columnName": "alertPhaseDaysBefore",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "disorderId"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `role` TEXT NOT NULL, `syncMode` TEXT NOT NULL, `couplePairingCode` TEXT, `partnerName` TEXT, `isPaired` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncMode",
+            "columnName": "syncMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "couplePairingCode",
+            "columnName": "couplePairingCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "partnerName",
+            "columnName": "partnerName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaired",
+            "columnName": "isPaired",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '074ea202ffa76e691470943ebbf074b6')"
+    ]
+  }
+}

--- a/app/schemas/fr.luteal.core.data.local.LutealDatabase/5.json
+++ b/app/schemas/fr.luteal.core.data.local.LutealDatabase/5.json
@@ -1,0 +1,379 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "074ea202ffa76e691470943ebbf074b6",
+    "entities": [
+      {
+        "tableName": "cycles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT, `periodDaysJson` TEXT NOT NULL, `averageLengthDays` INTEGER NOT NULL, `lutealPhaseLengthDays` INTEGER NOT NULL, `isSynced` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "periodDaysJson",
+            "columnName": "periodDaysJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "averageLengthDays",
+            "columnName": "averageLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lutealPhaseLengthDays",
+            "columnName": "lutealPhaseLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`entityId` TEXT NOT NULL, `entityType` TEXT NOT NULL, `clientRev` TEXT NOT NULL, `createdAtEpochMillis` INTEGER NOT NULL, `updatedAtEpochMillis` INTEGER NOT NULL, `deletedAtEpochMillis` INTEGER, `dirty` INTEGER NOT NULL, `lastPushError` TEXT, PRIMARY KEY(`entityId`))",
+        "fields": [
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientRev",
+            "columnName": "clientRev",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtEpochMillis",
+            "columnName": "createdAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updatedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAtEpochMillis",
+            "columnName": "deletedAtEpochMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dirty",
+            "columnName": "dirty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPushError",
+            "columnName": "lastPushError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "entityId"
+          ]
+        }
+      },
+      {
+        "tableName": "daily_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `bleedingIntensity` TEXT, `painLevel` INTEGER, `moodLevel` INTEGER, `energyLevel` INTEGER, `symptomIdsJson` TEXT NOT NULL, `notes` TEXT NOT NULL, `updatedAtEpochMillis` INTEGER NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bleedingIntensity",
+            "columnName": "bleedingIntensity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "painLevel",
+            "columnName": "painLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "moodLevel",
+            "columnName": "moodLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "energyLevel",
+            "columnName": "energyLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "symptomIdsJson",
+            "columnName": "symptomIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updatedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      },
+      {
+        "tableName": "symptom_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `date` TEXT NOT NULL, `timestampEpochMillis` INTEGER NOT NULL, `symptomId` TEXT NOT NULL, `severity` INTEGER NOT NULL, `notes` TEXT NOT NULL, `isSynced` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampEpochMillis",
+            "columnName": "timestampEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symptomId",
+            "columnName": "symptomId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "severity",
+            "columnName": "severity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "disorder_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`disorderId` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `customNotes` TEXT NOT NULL, `alertPhaseDaysBefore` INTEGER NOT NULL, PRIMARY KEY(`disorderId`))",
+        "fields": [
+          {
+            "fieldPath": "disorderId",
+            "columnName": "disorderId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNotes",
+            "columnName": "customNotes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertPhaseDaysBefore",
+            "columnName": "alertPhaseDaysBefore",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "disorderId"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `role` TEXT NOT NULL, `syncMode` TEXT NOT NULL, `couplePairingCode` TEXT, `partnerName` TEXT, `isPaired` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncMode",
+            "columnName": "syncMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "couplePairingCode",
+            "columnName": "couplePairingCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "partnerName",
+            "columnName": "partnerName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaired",
+            "columnName": "isPaired",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      },
+      {
+        "tableName": "duo_widget_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`linkId` TEXT NOT NULL, `role` TEXT NOT NULL, `cycleDay` INTEGER, `estimateStart` TEXT, `estimateEnd` TEXT, `cycleDayGranted` INTEGER NOT NULL, `estimateGranted` INTEGER NOT NULL, `status` TEXT NOT NULL, `refreshedAtEpochMillis` INTEGER NOT NULL, PRIMARY KEY(`linkId`))",
+        "fields": [
+          {
+            "fieldPath": "linkId",
+            "columnName": "linkId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cycleDay",
+            "columnName": "cycleDay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "estimateStart",
+            "columnName": "estimateStart",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "estimateEnd",
+            "columnName": "estimateEnd",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cycleDayGranted",
+            "columnName": "cycleDayGranted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "estimateGranted",
+            "columnName": "estimateGranted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refreshedAtEpochMillis",
+            "columnName": "refreshedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "linkId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '074ea202ffa76e691470943ebbf074b6')"
+    ]
+  }
+}

--- a/app/schemas/fr.luteal.core.data.local.LutealDatabase/6.json
+++ b/app/schemas/fr.luteal.core.data.local.LutealDatabase/6.json
@@ -1,0 +1,390 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "074ea202ffa76e691470943ebbf074b6",
+    "entities": [
+      {
+        "tableName": "cycles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT, `periodDaysJson` TEXT NOT NULL, `averageLengthDays` INTEGER NOT NULL, `lutealPhaseLengthDays` INTEGER NOT NULL, `isSynced` INTEGER NOT NULL, `isExcludedFromEstimates` INTEGER NOT NULL, `exclusionReason` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "periodDaysJson",
+            "columnName": "periodDaysJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "averageLengthDays",
+            "columnName": "averageLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lutealPhaseLengthDays",
+            "columnName": "lutealPhaseLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isExcludedFromEstimates",
+            "columnName": "isExcludedFromEstimates",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exclusionReason",
+            "columnName": "exclusionReason",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`entityId` TEXT NOT NULL, `entityType` TEXT NOT NULL, `clientRev` TEXT NOT NULL, `createdAtEpochMillis` INTEGER NOT NULL, `updatedAtEpochMillis` INTEGER NOT NULL, `deletedAtEpochMillis` INTEGER, `dirty` INTEGER NOT NULL, `lastPushError` TEXT, PRIMARY KEY(`entityId`))",
+        "fields": [
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientRev",
+            "columnName": "clientRev",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtEpochMillis",
+            "columnName": "createdAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updatedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAtEpochMillis",
+            "columnName": "deletedAtEpochMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dirty",
+            "columnName": "dirty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPushError",
+            "columnName": "lastPushError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "entityId"
+          ]
+        }
+      },
+      {
+        "tableName": "daily_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `bleedingIntensity` TEXT, `painLevel` INTEGER, `moodLevel` INTEGER, `energyLevel` INTEGER, `symptomIdsJson` TEXT NOT NULL, `notes` TEXT NOT NULL, `updatedAtEpochMillis` INTEGER NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bleedingIntensity",
+            "columnName": "bleedingIntensity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "painLevel",
+            "columnName": "painLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "moodLevel",
+            "columnName": "moodLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "energyLevel",
+            "columnName": "energyLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "symptomIdsJson",
+            "columnName": "symptomIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updatedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      },
+      {
+        "tableName": "symptom_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `date` TEXT NOT NULL, `timestampEpochMillis` INTEGER NOT NULL, `symptomId` TEXT NOT NULL, `severity` INTEGER NOT NULL, `notes` TEXT NOT NULL, `isSynced` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampEpochMillis",
+            "columnName": "timestampEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symptomId",
+            "columnName": "symptomId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "severity",
+            "columnName": "severity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "disorder_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`disorderId` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `customNotes` TEXT NOT NULL, `alertPhaseDaysBefore` INTEGER NOT NULL, PRIMARY KEY(`disorderId`))",
+        "fields": [
+          {
+            "fieldPath": "disorderId",
+            "columnName": "disorderId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNotes",
+            "columnName": "customNotes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertPhaseDaysBefore",
+            "columnName": "alertPhaseDaysBefore",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "disorderId"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `role` TEXT NOT NULL, `syncMode` TEXT NOT NULL, `couplePairingCode` TEXT, `partnerName` TEXT, `isPaired` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncMode",
+            "columnName": "syncMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "couplePairingCode",
+            "columnName": "couplePairingCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "partnerName",
+            "columnName": "partnerName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaired",
+            "columnName": "isPaired",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      },
+      {
+        "tableName": "duo_widget_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`linkId` TEXT NOT NULL, `role` TEXT NOT NULL, `cycleDay` INTEGER, `estimateStart` TEXT, `estimateEnd` TEXT, `cycleDayGranted` INTEGER NOT NULL, `estimateGranted` INTEGER NOT NULL, `status` TEXT NOT NULL, `refreshedAtEpochMillis` INTEGER NOT NULL, PRIMARY KEY(`linkId`))",
+        "fields": [
+          {
+            "fieldPath": "linkId",
+            "columnName": "linkId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cycleDay",
+            "columnName": "cycleDay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "estimateStart",
+            "columnName": "estimateStart",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "estimateEnd",
+            "columnName": "estimateEnd",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cycleDayGranted",
+            "columnName": "cycleDayGranted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "estimateGranted",
+            "columnName": "estimateGranted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refreshedAtEpochMillis",
+            "columnName": "refreshedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "linkId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '074ea202ffa76e691470943ebbf074b6')"
+    ]
+  }
+}

--- a/app/schemas/fr.luteal.core.data.local.LutealDatabase/8.json
+++ b/app/schemas/fr.luteal.core.data.local.LutealDatabase/8.json
@@ -1,0 +1,505 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "12b2b6e23b2015c4a1799ebd9ec193f5",
+    "entities": [
+      {
+        "tableName": "cycles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `startDate` TEXT NOT NULL, `endDate` TEXT, `periodDaysJson` TEXT NOT NULL, `averageLengthDays` INTEGER NOT NULL, `lutealPhaseLengthDays` INTEGER NOT NULL, `isSynced` INTEGER NOT NULL, `isExcludedFromEstimates` INTEGER NOT NULL, `exclusionReason` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "periodDaysJson",
+            "columnName": "periodDaysJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "averageLengthDays",
+            "columnName": "averageLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lutealPhaseLengthDays",
+            "columnName": "lutealPhaseLengthDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isExcludedFromEstimates",
+            "columnName": "isExcludedFromEstimates",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exclusionReason",
+            "columnName": "exclusionReason",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cycles_startDate",
+            "unique": false,
+            "columnNames": [
+              "startDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cycles_startDate` ON `${TABLE_NAME}` (`startDate`)"
+          },
+          {
+            "name": "index_cycles_endDate",
+            "unique": false,
+            "columnNames": [
+              "endDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cycles_endDate` ON `${TABLE_NAME}` (`endDate`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`entityId` TEXT NOT NULL, `entityType` TEXT NOT NULL, `clientRev` TEXT NOT NULL, `createdAtEpochMillis` INTEGER NOT NULL, `updatedAtEpochMillis` INTEGER NOT NULL, `deletedAtEpochMillis` INTEGER, `dirty` INTEGER NOT NULL, `lastPushError` TEXT, PRIMARY KEY(`entityId`))",
+        "fields": [
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientRev",
+            "columnName": "clientRev",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtEpochMillis",
+            "columnName": "createdAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updatedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAtEpochMillis",
+            "columnName": "deletedAtEpochMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dirty",
+            "columnName": "dirty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPushError",
+            "columnName": "lastPushError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "entityId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_state_dirty_entityType",
+            "unique": false,
+            "columnNames": [
+              "dirty",
+              "entityType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_state_dirty_entityType` ON `${TABLE_NAME}` (`dirty`, `entityType`)"
+          }
+        ]
+      },
+      {
+        "tableName": "daily_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `bleedingIntensity` TEXT, `painLevel` INTEGER, `moodLevel` INTEGER, `energyLevel` INTEGER, `symptomIdsJson` TEXT NOT NULL, `notes` TEXT NOT NULL, `updatedAtEpochMillis` INTEGER NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bleedingIntensity",
+            "columnName": "bleedingIntensity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "painLevel",
+            "columnName": "painLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "moodLevel",
+            "columnName": "moodLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "energyLevel",
+            "columnName": "energyLevel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "symptomIdsJson",
+            "columnName": "symptomIdsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updatedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      },
+      {
+        "tableName": "symptom_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `date` TEXT NOT NULL, `timestampEpochMillis` INTEGER NOT NULL, `symptomId` TEXT NOT NULL, `severity` INTEGER NOT NULL, `notes` TEXT NOT NULL, `isSynced` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampEpochMillis",
+            "columnName": "timestampEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symptomId",
+            "columnName": "symptomId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "severity",
+            "columnName": "severity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_symptom_logs_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_symptom_logs_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "disorder_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`disorderId` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL, `customNotes` TEXT NOT NULL, `alertPhaseDaysBefore` INTEGER NOT NULL, PRIMARY KEY(`disorderId`))",
+        "fields": [
+          {
+            "fieldPath": "disorderId",
+            "columnName": "disorderId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customNotes",
+            "columnName": "customNotes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertPhaseDaysBefore",
+            "columnName": "alertPhaseDaysBefore",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "disorderId"
+          ]
+        }
+      },
+      {
+        "tableName": "user_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `role` TEXT NOT NULL, `syncMode` TEXT NOT NULL, `couplePairingCode` TEXT, `partnerName` TEXT, `isPaired` INTEGER NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncMode",
+            "columnName": "syncMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "couplePairingCode",
+            "columnName": "couplePairingCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "partnerName",
+            "columnName": "partnerName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaired",
+            "columnName": "isPaired",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        }
+      },
+      {
+        "tableName": "duo_widget_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`linkId` TEXT NOT NULL, `role` TEXT NOT NULL, `cycleDay` INTEGER, `estimateStart` TEXT, `estimateEnd` TEXT, `cycleDayGranted` INTEGER NOT NULL, `estimateGranted` INTEGER NOT NULL, `status` TEXT NOT NULL, `refreshedAtEpochMillis` INTEGER NOT NULL, PRIMARY KEY(`linkId`))",
+        "fields": [
+          {
+            "fieldPath": "linkId",
+            "columnName": "linkId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cycleDay",
+            "columnName": "cycleDay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "estimateStart",
+            "columnName": "estimateStart",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "estimateEnd",
+            "columnName": "estimateEnd",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cycleDayGranted",
+            "columnName": "cycleDayGranted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "estimateGranted",
+            "columnName": "estimateGranted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refreshedAtEpochMillis",
+            "columnName": "refreshedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "linkId"
+          ]
+        }
+      },
+      {
+        "tableName": "biomarker_observations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `bbtCelsius` REAL, `bbtTime` TEXT, `bbtQuality` TEXT NOT NULL, `bbtDisturbancesJson` TEXT NOT NULL, `cervicalSensation` TEXT, `cervicalTexture` TEXT, `lhTestResult` TEXT, `hcgTestResult` TEXT, `notes` TEXT NOT NULL, `updatedAtEpochMillis` INTEGER NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bbtCelsius",
+            "columnName": "bbtCelsius",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "bbtTime",
+            "columnName": "bbtTime",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bbtQuality",
+            "columnName": "bbtQuality",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bbtDisturbancesJson",
+            "columnName": "bbtDisturbancesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cervicalSensation",
+            "columnName": "cervicalSensation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cervicalTexture",
+            "columnName": "cervicalTexture",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lhTestResult",
+            "columnName": "lhTestResult",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hcgTestResult",
+            "columnName": "hcgTestResult",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updatedAtEpochMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '12b2b6e23b2015c4a1799ebd9ec193f5')"
+    ]
+  }
+}

--- a/app/src/main/java/fr/luteal/app/LutealApp.kt
+++ b/app/src/main/java/fr/luteal/app/LutealApp.kt
@@ -8,6 +8,7 @@ import fr.luteal.app.widget.WidgetDataObserver
 import fr.luteal.app.widget.WidgetWorkScheduler
 import fr.luteal.app.notification.NotificationChannelManager
 import dagger.hilt.android.HiltAndroidApp
+import org.acra.ReportField
 import org.acra.config.dialog
 import org.acra.config.mailSender
 import org.acra.data.StringFormat
@@ -35,6 +36,19 @@ class LutealApp : Application(), Configuration.Provider {
         initAcra {
             buildConfigClass = BuildConfig::class.java
             reportFormat = StringFormat.JSON
+            reportContent = listOf(
+                ReportField.REPORT_ID,
+                ReportField.APP_VERSION_CODE,
+                ReportField.APP_VERSION_NAME,
+                ReportField.PACKAGE_NAME,
+                ReportField.ANDROID_VERSION,
+                ReportField.PHONE_MODEL,
+                ReportField.BRAND,
+                ReportField.PRODUCT,
+                ReportField.STACK_TRACE,
+                ReportField.USER_COMMENT,
+                ReportField.USER_CRASH_DATE
+            )
             dialog {
                 text = getString(R.string.crash_dialog_text)
                 title = getString(R.string.crash_dialog_title)

--- a/app/src/main/java/fr/luteal/app/LutealViewModel.kt
+++ b/app/src/main/java/fr/luteal/app/LutealViewModel.kt
@@ -152,8 +152,10 @@ class LutealViewModel @Inject constructor(
                         } else {
                             HtmlReportBuilder.writeHtmlToStream(data, stream)
                         }
-                    }
+                    } ?: throw IllegalStateException("Cannot open output stream for URI")
                 }
+            }.onFailure {
+                operationState.update { it.copy(failed = true) }
             }
         }
     }

--- a/app/src/main/java/fr/luteal/app/di/DatabaseModule.kt
+++ b/app/src/main/java/fr/luteal/app/di/DatabaseModule.kt
@@ -36,7 +36,8 @@ object DatabaseModule {
                 LutealDatabase.MIGRATION_3_4,
                 LutealDatabase.MIGRATION_4_5,
                 LutealDatabase.MIGRATION_5_6,
-                LutealDatabase.MIGRATION_6_7
+                LutealDatabase.MIGRATION_6_7,
+                LutealDatabase.MIGRATION_7_8
             ).build()
     }
 

--- a/app/src/main/java/fr/luteal/app/di/SyncModule.kt
+++ b/app/src/main/java/fr/luteal/app/di/SyncModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import fr.luteal.app.BuildConfig
 import fr.luteal.core.data.datastore.SyncDataStore
 import fr.luteal.core.data.local.BiomarkerDao
+import fr.luteal.core.data.local.LutealDatabase
 import fr.luteal.core.data.local.DailyEntryDao
 import fr.luteal.core.data.local.SyncStateDao
 import fr.luteal.core.data.local.SymptomDao
@@ -77,7 +78,8 @@ abstract class SyncModule {
             credentialStore: SyncCredentialStore,
             apiClientFactory: FolicularApiClientFactory,
             cursorStore: SyncCursorStore,
-            recordSealer: RecordSealer
+            recordSealer: RecordSealer,
+            database: LutealDatabase
         ): CycleSyncEngine = CycleSyncEngine(
             cycleRepository = cycleRepository,
             syncStateDao = syncStateDao,
@@ -87,7 +89,8 @@ abstract class SyncModule {
             credentialStore = credentialStore,
             apiClientFactory = apiClientFactory,
             cursorStore = cursorStore,
-            recordSealer = recordSealer
+            recordSealer = recordSealer,
+            database = database
         )
     }
 }

--- a/app/src/main/java/fr/luteal/app/navigation/AppLockScreen.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/AppLockScreen.kt
@@ -93,6 +93,7 @@ fun AppLockScreen(
     val scope = rememberCoroutineScope()
     val haptics = LocalHapticFeedback.current
 
+
     // Handle lockout countdown timer
     LaunchedEffect(currentLockoutSeconds) {
         if (currentLockoutSeconds > 0) {

--- a/app/src/main/java/fr/luteal/app/navigation/CycleVariabilityVisualizer.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/CycleVariabilityVisualizer.kt
@@ -62,8 +62,8 @@ import fr.luteal.core.model.LongitudinalCycleStats
 fun CycleVariabilityVisualizer(
     stats: LongitudinalCycleStats,
     onManageExclusion: (String) -> Unit,
-    onStartPeriod: () -> Unit = {},
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onStartPeriod: () -> Unit = {}
 ) {
     var selectedCycleItem by remember { mutableStateOf<LongitudinalCycleItem?>(null) }
 

--- a/app/src/main/java/fr/luteal/app/navigation/DuoScreen.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/DuoScreen.kt
@@ -293,6 +293,7 @@ private fun InvitationPendingSection(
 ) {
     val context = LocalContext.current
     var copied by remember { mutableStateOf(false) }
+    val duoCodeLabel = stringResource(R.string.duo_code_label)
 
     LutealCard(modifier = Modifier.fillMaxWidth()) {
         Column(verticalArrangement = Arrangement.spacedBy(LutealSpacing.sm)) {

--- a/app/src/main/java/fr/luteal/app/navigation/JournalScreen.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/JournalScreen.kt
@@ -225,6 +225,7 @@ fun JournalScreen(
         }
 
         item {
+            @Suppress("DEPRECATION")
             ScrollableTabRow(
                 selectedTabIndex = viewMode.ordinal,
                 containerColor = MaterialTheme.colorScheme.surface,
@@ -645,9 +646,9 @@ private fun SelectedDayInspectionCard(
 
             if (hasObservations) {
                 val levels = listOfNotNull(
-                    entry?.painLevel?.let { stringResource(R.string.level_label_pain) to it },
-                    entry?.moodLevel?.let { stringResource(R.string.level_label_mood) to it },
-                    entry?.energyLevel?.let { stringResource(R.string.level_label_energy) to it }
+                    entry.painLevel?.let { stringResource(R.string.level_label_pain) to it },
+                    entry.moodLevel?.let { stringResource(R.string.level_label_mood) to it },
+                    entry.energyLevel?.let { stringResource(R.string.level_label_energy) to it }
                 )
                 if (levels.isNotEmpty()) {
                     FlowRow(
@@ -660,7 +661,7 @@ private fun SelectedDayInspectionCard(
                     }
                 }
 
-                val trailing = entry?.let { journalEntryTrailingSummary(it) }.orEmpty()
+                val trailing = journalEntryTrailingSummary(entry)
                 if (trailing.isNotEmpty()) {
                     Text(
                         text = trailing,
@@ -669,9 +670,9 @@ private fun SelectedDayInspectionCard(
                     )
                 }
 
-                if (!entry?.notes.isNullOrBlank()) {
+                if (entry.notes.isNotBlank()) {
                     Text(
-                        text = entry?.notes.orEmpty(),
+                        text = entry.notes,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )

--- a/app/src/main/java/fr/luteal/app/navigation/SettingsScreen.kt
+++ b/app/src/main/java/fr/luteal/app/navigation/SettingsScreen.kt
@@ -490,7 +490,8 @@ private fun SetPinDialog(
     var pin by remember { mutableStateOf("") }
     var confirmPin by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
-    val context = LocalContext.current
+    val errorLength = stringResource(R.string.dialog_set_pin_error_length)
+    val errorMatch = stringResource(R.string.dialog_set_pin_error_match)
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -750,7 +751,9 @@ private fun ChangePinDialog(
     var confirmNewPin by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
     var verifying by remember { mutableStateOf(false) }
-    val context = LocalContext.current
+    val errorCurrent = stringResource(R.string.dialog_change_pin_error_current)
+    val errorLength = stringResource(R.string.dialog_set_pin_error_length)
+    val errorMatch = stringResource(R.string.dialog_set_pin_error_match)
     val scope = rememberCoroutineScope()
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -843,7 +846,7 @@ private fun DisableLockDialog(
     var pin by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
     var verifying by remember { mutableStateOf(false) }
-    val context = LocalContext.current
+    val errorDisable = stringResource(R.string.dialog_disable_lock_error)
     val scope = rememberCoroutineScope()
 
     AlertDialog(
@@ -1597,6 +1600,7 @@ private fun AccountCodeSection(state: SettingsSyncUiState, getAccountCode: () ->
     }
     val context = LocalContext.current
     var copied by remember { mutableStateOf(false) }
+    val accountCodeTitle = stringResource(R.string.settings_sync_account_code_title)
 
     Column(verticalArrangement = Arrangement.spacedBy(LutealSpacing.xs)) {
         Text(

--- a/app/src/main/java/fr/luteal/app/notification/NotificationAlarmReceiver.kt
+++ b/app/src/main/java/fr/luteal/app/notification/NotificationAlarmReceiver.kt
@@ -1,11 +1,13 @@
 package fr.luteal.app.notification
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
-import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import dagger.hilt.android.AndroidEntryPoint
@@ -92,8 +94,14 @@ class NotificationAlarmReceiver : BroadcastReceiver() {
                     NotificationType.LATE_CYCLE -> 2003
                 }
 
-                if (ActivityCompat.checkSelfPermission(context, android.Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
-                    NotificationManagerCompat.from(context).notify(notificationId, notification)
+                val hasPermission = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+                    ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+                if (hasPermission) {
+                    try {
+                        NotificationManagerCompat.from(context).notify(notificationId, notification)
+                    } catch (_: SecurityException) {
+                        // Suppressed if runtime notification permission was concurrently revoked
+                    }
                 }
 
                 // Reschedule next occurrence

--- a/app/src/main/java/fr/luteal/core/data/entity/CycleEntity.kt
+++ b/app/src/main/java/fr/luteal/core/data/entity/CycleEntity.kt
@@ -1,9 +1,16 @@
 package fr.luteal.core.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "cycles")
+@Entity(
+    tableName = "cycles",
+    indices = [
+        Index(value = ["startDate"]),
+        Index(value = ["endDate"])
+    ]
+)
 data class CycleEntity(
     @PrimaryKey val id: String,
     val startDate: String,

--- a/app/src/main/java/fr/luteal/core/data/entity/SymptomLogEntity.kt
+++ b/app/src/main/java/fr/luteal/core/data/entity/SymptomLogEntity.kt
@@ -1,9 +1,15 @@
 package fr.luteal.core.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "symptom_logs")
+@Entity(
+    tableName = "symptom_logs",
+    indices = [
+        Index(value = ["date"])
+    ]
+)
 data class SymptomLogEntity(
     @PrimaryKey val id: String,
     val date: String,

--- a/app/src/main/java/fr/luteal/core/data/entity/SyncStateEntity.kt
+++ b/app/src/main/java/fr/luteal/core/data/entity/SyncStateEntity.kt
@@ -1,6 +1,7 @@
 package fr.luteal.core.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 /**
@@ -10,7 +11,12 @@ import androidx.room.PrimaryKey
  *
  * Replaces the former cycle-only `cycle_sync_state` table (v3).
  */
-@Entity(tableName = "sync_state")
+@Entity(
+    tableName = "sync_state",
+    indices = [
+        Index(value = ["dirty", "entityType"])
+    ]
+)
 data class SyncStateEntity(
     @PrimaryKey val entityId: String,
     val entityType: String,

--- a/app/src/main/java/fr/luteal/core/data/local/LutealDatabase.kt
+++ b/app/src/main/java/fr/luteal/core/data/local/LutealDatabase.kt
@@ -25,7 +25,7 @@ import fr.luteal.core.data.entity.UserProfileEntity
         DuoWidgetCacheEntity::class,
         BiomarkerObservationEntity::class
     ],
-    version = 7,
+    version = 8,
     // Exported to app/schemas (room.schemaLocation) so MigrationTestHelper
     // can validate future migrations against the real schema history.
     exportSchema = true
@@ -152,6 +152,15 @@ abstract class LutealDatabase : RoomDatabase() {
                     )
                     """.trimIndent()
                 )
+            }
+        }
+
+        val MIGRATION_7_8 = object : Migration(7, 8) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_symptom_logs_date` ON `symptom_logs` (`date`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_sync_state_dirty_entityType` ON `sync_state` (`dirty`, `entityType`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_cycles_startDate` ON `cycles` (`startDate`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_cycles_endDate` ON `cycles` (`endDate`)")
             }
         }
     }

--- a/app/src/main/java/fr/luteal/core/data/report/PdfReportBuilder.kt
+++ b/app/src/main/java/fr/luteal/core/data/report/PdfReportBuilder.kt
@@ -67,16 +67,62 @@ object PdfReportBuilder {
             style = Paint.Style.FILL
         }
 
-        val pageInfo = PdfDocument.PageInfo.Builder(PAGE_WIDTH, PAGE_HEIGHT, 1).create()
-        val page = document.startPage(pageInfo)
-        val canvas: Canvas = page.canvas
+        val title = if (isFr) "Récapitulatif de consultation médicale" else "Clinical Consultation Summary Report"
+        val footerY = PAGE_HEIGHT - MARGIN - 15f
+        val disclaimerText = if (isFr) {
+            "Document purement descriptif établi à partir des observations saisies par la personne. Ne constitue pas un diagnostic médical."
+        } else {
+            "Descriptive document generated from user observations. Does not constitute a clinical diagnosis or interpretation."
+        }
+
+        var pageNumber = 1
+        var page = document.startPage(PdfDocument.PageInfo.Builder(PAGE_WIDTH, PAGE_HEIGHT, pageNumber).create())
+        var canvas: Canvas = page.canvas
 
         var y = MARGIN + 10f
+
+        fun drawFooter(c: Canvas, num: Int) {
+            c.drawLine(MARGIN, footerY - 5f, MARGIN + CONTENT_WIDTH, footerY - 5f, linePaint)
+            c.drawText(disclaimerText, MARGIN, footerY + 8f, secondaryPaint)
+            c.drawText("$num", MARGIN + CONTENT_WIDTH - 15f, footerY + 8f, secondaryPaint)
+        }
+
+        fun drawTableHeader(c: Canvas, atY: Float) {
+            c.drawRect(MARGIN, atY - 10f, MARGIN + CONTENT_WIDTH, atY + 4f, boxPaint)
+            c.drawText(if (isFr) "Symptôme" else "Symptom", MARGIN + 6f, atY, boldPaint)
+            c.drawText(if (isFr) "Total" else "Total", MARGIN + 220f, atY, boldPaint)
+            c.drawText(if (isFr) "Règles" else "Menses", MARGIN + 310f, atY, boldPaint)
+            c.drawText(if (isFr) "Hors règles" else "Non-menses", MARGIN + 400f, atY, boldPaint)
+        }
+
+        fun newPage(isTableContinuation: Boolean = false) {
+            drawFooter(canvas, pageNumber)
+            document.finishPage(page)
+            pageNumber++
+            page = document.startPage(PdfDocument.PageInfo.Builder(PAGE_WIDTH, PAGE_HEIGHT, pageNumber).create())
+            canvas = page.canvas
+            y = MARGIN + 10f
+            canvas.drawText("LUTEAL", MARGIN, y, secondaryPaint)
+            y += 14f
+            canvas.drawText(title, MARGIN, y, headerPaint)
+            y += 10f
+            canvas.drawLine(MARGIN, y, MARGIN + CONTENT_WIDTH, y, linePaint)
+            y += 16f
+            if (isTableContinuation) {
+                drawTableHeader(canvas, y)
+                y += 15f
+            }
+        }
+
+        fun ensureSpace(needed: Float, isTableContinuation: Boolean = false) {
+            if (y + needed > footerY - 12f) {
+                newPage(isTableContinuation)
+            }
+        }
 
         // Brand & Header
         canvas.drawText("LUTEAL", MARGIN, y, secondaryPaint)
         y += 18f
-        val title = if (isFr) "Récapitulatif de consultation médicale" else "Clinical Consultation Summary Report"
         canvas.drawText(title, MARGIN, y, titlePaint)
         y += 14f
 
@@ -92,6 +138,7 @@ object PdfReportBuilder {
         y += 20f
 
         // Section 1: Cycle Statistics
+        ensureSpace(60f)
         canvas.drawText(if (isFr) "1. Synthèse des cycles" else "1. Cycle Overview", MARGIN, y, headerPaint)
         y += 14f
 
@@ -117,6 +164,7 @@ object PdfReportBuilder {
         y += (metrics.size / 3 * 16f) + 16f
 
         // Section 2: Bleeding & Pain summary
+        ensureSpace(80f)
         canvas.drawText(if (isFr) "2. Saignements et Douleurs" else "2. Bleeding & Pain Dynamics", MARGIN, y, headerPaint)
         y += 14f
 
@@ -130,6 +178,7 @@ object PdfReportBuilder {
         )
 
         for (metric in healthMetrics) {
+            ensureSpace(14f)
             canvas.drawText("• $metric", MARGIN + 4f, y, textPaint)
             y += 14f
         }
@@ -137,19 +186,15 @@ object PdfReportBuilder {
 
         // Section 3: Symptom Frequency Matrix
         if (data.symptomFrequencies.isNotEmpty()) {
+            ensureSpace(40f)
             canvas.drawText(if (isFr) "3. Fréquence des symptômes" else "3. Symptom Frequencies", MARGIN, y, headerPaint)
             y += 14f
 
-            // Table header
-            canvas.drawRect(MARGIN, y - 10f, MARGIN + CONTENT_WIDTH, y + 4f, boxPaint)
-            canvas.drawText(if (isFr) "Symptôme" else "Symptom", MARGIN + 6f, y, boldPaint)
-            canvas.drawText(if (isFr) "Total" else "Total", MARGIN + 220f, y, boldPaint)
-            canvas.drawText(if (isFr) "Règles" else "Menses", MARGIN + 310f, y, boldPaint)
-            canvas.drawText(if (isFr) "Hors règles" else "Non-menses", MARGIN + 400f, y, boldPaint)
+            drawTableHeader(canvas, y)
             y += 15f
 
-            val displaySymptoms = data.symptomFrequencies.take(8)
-            for (sym in displaySymptoms) {
+            for (sym in data.symptomFrequencies) {
+                ensureSpace(14f, isTableContinuation = true)
                 val name = if (isFr) sym.symptomNameFr else sym.symptomNameEn
                 canvas.drawText(name, MARGIN + 6f, y, textPaint)
                 canvas.drawText("${sym.totalOccurrences} j", MARGIN + 220f, y, textPaint)
@@ -162,11 +207,12 @@ object PdfReportBuilder {
 
         // Section 4: Notes (if included)
         if (data.notes.isNotEmpty()) {
+            ensureSpace(30f)
             canvas.drawText(if (isFr) "4. Notes et observations" else "4. Notes & Observations", MARGIN, y, headerPaint)
             y += 14f
 
-            val displayNotes = data.notes.take(5)
-            for (note in displayNotes) {
+            for (note in data.notes) {
+                ensureSpace(14f)
                 val truncatedNote = if (note.notes.length > 70) note.notes.take(67) + "…" else note.notes
                 canvas.drawText("${note.date} : $truncatedNote", MARGIN + 4f, y, textPaint)
                 y += 12f
@@ -174,16 +220,7 @@ object PdfReportBuilder {
             y += 10f
         }
 
-        // Disclaimer at footer
-        val footerY = PAGE_HEIGHT - MARGIN - 15f
-        canvas.drawLine(MARGIN, footerY - 5f, MARGIN + CONTENT_WIDTH, footerY - 5f, linePaint)
-        val disclaimerText = if (isFr) {
-            "Document purement descriptif établi à partir des observations saisies par la personne. Ne constitue pas un diagnostic médical."
-        } else {
-            "Descriptive document generated from user observations. Does not constitute a clinical diagnosis or interpretation."
-        }
-        canvas.drawText(disclaimerText, MARGIN, footerY + 8f, secondaryPaint)
-
+        drawFooter(canvas, pageNumber)
         document.finishPage(page)
         document.writeTo(outputStream)
         document.close()

--- a/app/src/main/java/fr/luteal/core/network/ContractSerializers.kt
+++ b/app/src/main/java/fr/luteal/core/network/ContractSerializers.kt
@@ -1,5 +1,6 @@
 package fr.luteal.core.network
 
+import fr.luteal.core.network.contract.models.EntityType
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
@@ -51,6 +52,20 @@ object OffsetDateTimeSerializer : KSerializer<OffsetDateTime> {
 
     override fun deserialize(decoder: Decoder): OffsetDateTime =
         OffsetDateTime.parse(decoder.decodeString(), DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+}
+
+object SafeEntityTypeSerializer : KSerializer<EntityType?> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("fr.luteal.core.network.SafeEntityType", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: EntityType?) {
+        encoder.encodeString(value?.value ?: "unknown")
+    }
+
+    override fun deserialize(decoder: Decoder): EntityType? {
+        val raw = decoder.decodeString()
+        return EntityType.entries.firstOrNull { it.value == raw }
+    }
 }
 
 val ContractSerializersModule: SerializersModule = SerializersModule {

--- a/app/src/main/java/fr/luteal/core/network/SyncWire.kt
+++ b/app/src/main/java/fr/luteal/core/network/SyncWire.kt
@@ -58,7 +58,7 @@ data class PushRequestWire(
 
 @Serializable
 data class ConflictWire(
-    @SerialName("entity_type") val entityType: EntityType,
+    @Serializable(with = SafeEntityTypeSerializer::class) @SerialName("entity_type") val entityType: EntityType? = null,
     @Contextual @SerialName("entity_id") val entityId: UUID,
     @SerialName("reason") val reason: String,
     @Contextual @SerialName("current_client_rev") val currentClientRev: UUID,
@@ -80,7 +80,7 @@ data class PushResultWire(
 @Serializable
 data class PullChangeWire(
     @SerialName("seq") val seq: Long,
-    @SerialName("entity_type") val entityType: EntityType,
+    @Serializable(with = SafeEntityTypeSerializer::class) @SerialName("entity_type") val entityType: EntityType? = null,
     @Contextual @SerialName("entity_id") val entityId: UUID,
     @Contextual @SerialName("client_rev") val clientRev: UUID,
     @SerialName("deleted") val deleted: Boolean,
@@ -207,13 +207,15 @@ fun fr.luteal.core.network.mapping.BiomarkerObservationPayload.toPushChange(
 /** Opens a pulled change, or returns null for a tombstone. */
 fun PullChangeWire.openPayload(sealer: RecordSealer): JsonElement? {
     val sealed = ciphertext ?: return null
-    return sealer.open(entityType.value, entityId.toString(), clientRev.toString(), sealed)
+    val type = entityType ?: return null
+    return sealer.open(type.value, entityId.toString(), clientRev.toString(), sealed)
 }
 
 /** Opens the server's current state from a conflict, or null for a tombstone. */
 fun ConflictWire.openCurrent(sealer: RecordSealer): JsonElement? {
     val sealed = currentCiphertext ?: return null
+    val type = entityType ?: return null
     return sealer.open(
-        entityType.value, entityId.toString(), currentClientRev.toString(), sealed
+        type.value, entityId.toString(), currentClientRev.toString(), sealed
     )
 }

--- a/app/src/main/java/fr/luteal/core/network/sync/CycleSyncEngine.kt
+++ b/app/src/main/java/fr/luteal/core/network/sync/CycleSyncEngine.kt
@@ -1,5 +1,7 @@
 package fr.luteal.core.network.sync
 
+import androidx.room.withTransaction
+import fr.luteal.core.data.local.LutealDatabase
 import fr.luteal.core.data.entity.SyncStateEntity
 import fr.luteal.core.data.local.BiomarkerDao
 import fr.luteal.core.data.local.DailyEntryDao
@@ -126,7 +128,8 @@ class CycleSyncEngine(
     private val credentialStore: SyncCredentialStore,
     private val apiClientFactory: FolicularApiClientFactory,
     private val cursorStore: SyncCursorStore,
-    private val recordSealer: RecordSealer
+    private val recordSealer: RecordSealer,
+    private val database: LutealDatabase? = null
 ) {
 
     suspend fun sync(): SyncReport {
@@ -522,6 +525,14 @@ class CycleSyncEngine(
     private data class PageOutcome(val recordsApplied: Int, val tombstonesApplied: Int)
 
     private suspend fun applyPage(changes: List<PullChangeWire>): PageOutcome {
+        return if (database != null) {
+            database.withTransaction { applyPageInternal(changes) }
+        } else {
+            applyPageInternal(changes)
+        }
+    }
+
+    private suspend fun applyPageInternal(changes: List<PullChangeWire>): PageOutcome {
         val localCyclesById = cycleRepository.getCyclesOnce().associateBy { it.id }
 
         // Decode live bleeding observations for cycle period-day association.

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="app_name">Luteal</string>
 
@@ -62,16 +62,10 @@
     <string name="nav_settings">Réglages</string>
 
     <string name="today_title">Aujourd’hui</string>
-    <string name="today_greeting">Votre suivi, en toute simplicité</string>
     <string name="cycle_day">Jour %1$d du cycle</string>
     <string name="cycle_day_caption">Jour du cycle</string>
-    <string name="cycle_started_on">Cycle commencé le %1$s</string>
     <string name="cycle_no_history_title">Commencez quand vous le souhaitez</string>
     <string name="cycle_no_history_body">Enregistrez le premier jour de vos règles pour démarrer votre historique. Vous pourrez ensuite le compléter jour après jour.</string>
-    <string name="action_start_period">Enregistrer le début des règles</string>
-    <string name="today_entry_title">Observations du jour</string>
-    <string name="today_entry_empty">Aucune observation enregistrée aujourd’hui.</string>
-    <string name="today_entry_complete">Vos observations sont enregistrées sur cet appareil.</string>
     <string name="action_log_today">Noter aujourd’hui</string>
     <string name="action_edit_today">Modifier les observations</string>
     <string name="estimate_title">Prochaines règles</string>
@@ -81,7 +75,6 @@
         <item quantity="many">Plage estimée à partir de %1$d intervalles de cycle enregistrés.</item>
         <item quantity="other">Plage estimée à partir de %1$d intervalles de cycle enregistrés.</item>
     </plurals>
-    <string name="estimate_unavailable">Une plage estimée apparaîtra après au moins deux débuts de cycle enregistrés.</string>
     <string name="estimate_disclaimer">Cette estimation repose uniquement sur votre historique enregistré et peut évoluer.</string>
     <string name="estimate_window_a11y">Fenêtre estimée de %1$d jours</string>
     <string name="recorded_label">Enregistré</string>
@@ -144,19 +137,10 @@
     <string name="journal_empty_title">Votre journal est encore vide</string>
     <string name="journal_empty_body">Ajoutez une première observation pour construire un historique personnel.</string>
     <string name="journal_today">Aujourd’hui</string>
-    <plurals name="journal_observation_count">
-        <item quantity="one">%1$d observation</item>
-        <item quantity="many">%1$d observations</item>
-        <item quantity="other">%1$d observations</item>
-    </plurals>
     <string name="journal_no_observation">Aucune observation</string>
     <string name="action_add_observation">Ajouter une observation</string>
     <string name="journal_choose_date">Choisir une date</string>
     <string name="journal_open_date">Ouvrir cette date</string>
-    <string name="journal_summary_bleeding">Saignements</string>
-    <string name="journal_summary_pain">Douleur %1$d/5</string>
-    <string name="journal_summary_mood">Humeur %1$d/5</string>
-    <string name="journal_summary_energy">Énergie %1$d/5</string>
     <plurals name="journal_summary_other_count">
         <item quantity="one">%1$d autre observation</item>
         <item quantity="many">%1$d autres observations</item>
@@ -183,7 +167,6 @@
     <string name="editor_pain">Douleur</string>
     <string name="editor_mood">Humeur</string>
     <string name="editor_energy">Énergie</string>
-    <string name="editor_scale_hint">1 signifie faible, 5 signifie élevé.</string>
     <string name="editor_pain_scale_support">1 : aucune, 5 : très forte</string>
     <string name="editor_mood_scale_support">1 : très difficile, 5 : très agréable</string>
     <string name="editor_energy_scale_support">1 : très basse, 5 : très élevée</string>
@@ -225,11 +208,8 @@
     <string name="editor_discard_body">Les modifications saisies pour cette date seront perdues.</string>
     <string name="editor_discard_confirm">Quitter sans enregistrer</string>
     <string name="editor_keep_editing">Continuer la saisie</string>
-    <string name="action_retry">Réessayer</string>
-
     <string name="duo_title">Duo</string>
     <string name="duo_subtitle">Préparez ce que vous souhaiterez partager, avant toute connexion.</string>
-    <string name="duo_local_status">Configuration locale</string>
     <string name="duo_not_connected_title">Aucun partenaire connecté</string>
     <string name="duo_not_connected_body">Créez une invitation ou saisissez le code de votre partenaire pour établir un lien. Vous choisirez ensuite ce que vous partagez, catégorie par catégorie, et vous pourrez le révoquer à tout moment.</string>
     <string name="duo_sharing_title">Ce que vous autorisez</string>
@@ -249,14 +229,6 @@
     <string name="duo_share_support_desc">Permettre le partage de demandes que vous formulez vous-même.</string>
     <string name="duo_preview_title">Aperçu partenaire</string>
     <string name="duo_preview_body">Cet aperçu montre seulement les catégories autorisées. Aucune donnée n’est transmise.</string>
-    <string name="duo_preview_hidden">Aucune donnée de suivi n’est visible avec les autorisations actuelles.</string>
-    <string name="duo_preview_cycle_day">Jour du cycle partagé : %1$d</string>
-    <string name="duo_preview_no_cycle">Aucun jour de cycle à partager</string>
-    <string name="duo_preview_estimate">Plage partagée : %1$s au %2$s</string>
-    <string name="duo_preview_mood">Humeur partagée : %1$d sur 5</string>
-    <string name="duo_preview_energy">Énergie partagée : %1$d sur 5</string>
-    <string name="duo_preview_support_ready">Demandes de soutien que vous formulez</string>
-    <string name="duo_preview_local_label">Aperçu local</string>
     <string name="duo_error_invalid_pairing_link">Lien de partage incomplet : utilisez le lien complet fourni par votre partenaire.</string>
     <string name="duo_private_notes_never_shared">Les notes privées ne sont jamais incluses dans le partage Duo.</string>
 
@@ -269,13 +241,11 @@
     <string name="settings_backup_body">Les données sensibles de Luteal ne sont pas incluses dans la sauvegarde cloud Android.</string>
     <string name="settings_sync_title">Synchronisation</string>
     <string name="settings_sync_body">Activez la synchronisation pour retrouver vos données sur vos appareils. Vos observations restent enregistrées sur cet appareil ; la synchronisation s’effectue en arrière-plan et ne bloque jamais l’application. Aucune connexion n’est établie sans votre activation.</string>
-    <string name="settings_sync_trial_body">Reliez cet appareil à un serveur folicular local pour tester la synchronisation des cycles. Vos données restent enregistrées sur cet appareil ; la synchronisation s’effectue en arrière-plan et ne bloque jamais l’application. Aucune connexion n’est établie sans votre activation.</string>
     <string name="sync_transport_notice">Vos observations sont chiffrées de bout en bout sur cet appareil avant tout envoi : le serveur ne conserve que des données illisibles pour lui. Il voit malgré tout la date de vos synchronisations et le nombre d’enregistrements. Votre code de compte est la seule clé : sans lui, personne ne peut déchiffrer vos données, y compris nous.</string>
     <string name="settings_sync_online_title">Mode en ligne</string>
     <string name="settings_sync_online_body">Active la synchronisation avec le serveur Luteal. Désactivée par défaut.</string>
     <string name="settings_sync_server_body">Par défaut, la synchronisation utilise le serveur officiel Luteal. Vous pouvez également renseigner l’adresse de votre propre instance folicular auto-hébergée.</string>
     <string name="settings_sync_base_url_label">Adresse du serveur</string>
-    <string name="settings_sync_base_url_default">http://10.0.2.2:8080</string>
     <string name="settings_sync_save">Enregistrer</string>
     <string name="settings_sync_now">Synchroniser maintenant</string>
     <string name="settings_sync_in_progress">Synchronisation en cours…</string>
@@ -292,10 +262,9 @@
     <string name="settings_recovery_action">Restaurer ce compte</string>
     <string name="settings_recovery_in_progress">Restauration en cours…</string>
     <string name="settings_recovery_success">Compte restauré. La synchronisation va récupérer votre historique.</string>
-    <string name="settings_recovery_error_already_linked">Cet appareil est déjà relié à un compte. Effacez les données locales avant de restaurer un autre compte.</string>
     <string name="settings_recovery_error_failed">La restauration a échoué. Vérifiez le code de compte et votre connexion.</string>
     <string name="settings_sync_last_success">Dernière synchronisation : %1$s</string>
-    <string name="sync_error_auth_rejected">Le serveur ne reconnaît plus cet appareil. Reconnectez le compte depuis Réglages > Synchronisation avec votre code de compte.</string>
+    <string name="sync_error_auth_rejected">Le serveur ne reconnaît plus cet appareil. Reconnectez le compte depuis Réglages &gt; Synchronisation avec votre code de compte.</string>
     <string name="settings_sync_last_error">Échec de la synchronisation : %1$s</string>
     <string name="settings_appearance_title">Apparence</string>
     <string name="settings_appearance_body">Le thème clair ou sombre suit le réglage de votre appareil.</string>
@@ -315,15 +284,8 @@
 
     <string name="backfill_title">Ajouter un cycle passé</string>
     <string name="backfill_body">Renseignez les dates de début de vos derniers cycles pour obtenir des estimations plus rapidement. Vous pouvez ajouter jusqu’à 3 mois d’historique.</string>
-    <string name="backfill_date_label">Date de début des règles</string>
     <string name="backfill_confirm">Ajouter ce cycle</string>
     <string name="backfill_action">Ajouter un cycle passé</string>
-    <string name="backfill_already_exists">Un cycle existe déjà à cette date.</string>
-
-
-    <string name="content_description_previous_day">Jour précédent</string>
-    <string name="content_description_next_day">Jour suivant</string>
-    <string name="content_description_selected_tab">Section sélectionnée : %1$s</string>
     <string name="onboarding_title">Bienvenue dans Luteal</string>
     <string name="onboarding_subtitle">Un suivi de cycle privé, hors-ligne et respectueux de vos données.</string>
     <string name="onboarding_welcome_step_title">Vos données restent sur cet appareil</string>
@@ -393,12 +355,7 @@
     <string name="onboarding_button_back">Retour</string>
     <string name="onboarding_button_start">Démarrer</string>
     <string name="onboarding_button_skip">Passer l’introduction</string>
-    <string name="action_start_period_today">Déclarer mes règles aujourd’hui</string>
-    <string name="action_start_period_today_desc">Démarre un nouveau cycle à la date d’aujourd’hui.</string>
-    <string name="action_log_daily_entry">Noter la journée</string>
-    <string name="action_edit_daily_entry">Modifier mes notes du jour</string>
     <string name="today_summary_title">Observations d’aujourd’hui</string>
-    <string name="today_summary_empty_title">Aucune observation enregistrée</string>
     <string name="today_summary_empty_body">Prenez un instant pour noter votre flux, vos ressentis ou votre niveau d’énergie.</string>
     <string name="today_bleeding_label">Flux : %1$s</string>
     <string name="today_pain_label">Douleur : %1$d/5</string>
@@ -416,9 +373,6 @@
     </plurals>
     <string name="estimate_in_progress">Plage des règles estimée en cours</string>
     <string name="action_start_period_short">Début des règles</string>
-    <string name="action_log_entry_short">Noter la journée</string>
-    <string name="today_summary_empty_short">Aucune observation saisie</string>
-    <string name="today_summary_open_hint">Ouvrir pour ajouter une observation</string>
     <string name="estimate_unavailable_short">En attente d’historique (2 cycles)</string>
     <string name="estimate_unavailable_hint">Enregistrez vos cycles au fur et à mesure, ou ajoutez vos derniers cycles passés pour obtenir une estimation.</string>
     <string name="estimate_out_of_range_short">Estimation indisponible pour vos cycles</string>
@@ -428,7 +382,6 @@
         <item quantity="many">Plage dépassée depuis %1$d jours</item>
         <item quantity="other">Plage dépassée depuis %1$d jours</item>
     </plurals>
-    <string name="cycle_no_history_short">Aucun cycle en cours</string>
     <string name="crash_dialog_title">Luteal a rencontré un problème</string>
     <string name="crash_dialog_text">L’application s’est arrêtée de manière inattendue. Vous pouvez envoyer un rapport anonyme pour nous aider à corriger ce problème. Aucune donnée de suivi n’est incluse.</string>
     <string name="crash_dialog_comment">Décrivez ce que vous faisiez (facultatif)</string>
@@ -473,9 +426,7 @@
     <string name="duo_support_kind_space">Espace</string>
     <string name="duo_refresh">Actualiser</string>
 
-    <!-- Calendar Screen & Grid -->
-    <string name="calendar_title">Calendrier</string>
-    <string name="calendar_subtitle">Vue mensuelle de vos cycles et observations</string>
+    
     <string name="calendar_view_calendar">Calendrier</string>
     <string name="calendar_view_list">Historique</string>
     <string name="calendar_previous_month">Mois précédent</string>
@@ -486,15 +437,9 @@
     <string name="calendar_legend_estimated_period">Plage estimée</string>
     <string name="calendar_legend_observation">Observations (douleur, humeur, etc.)</string>
     <string name="calendar_day_cd_recorded">%1$s, règles (%2$s)</string>
-    <string name="calendar_day_cd_estimated">%1$s, plage estimée de règles</string>
-    <string name="calendar_day_cd_observations">%1$s, %2$d observation(s)</string>
     <string name="calendar_day_empty_inspection">Aucune observation enregistrée pour cette journée.</string>
-    <string name="calendar_day_inspection_title">Détails de la journée</string>
-
-    <!-- Cycle Management -->
     <string name="cycle_action_edit">Modifier le début du cycle</string>
     <string name="cycle_action_delete">Supprimer le cycle</string>
-    <string name="cycle_edit_title">Modifier la date de début</string>
     <string name="cycle_edit_body">Choisissez la date de début de ce cycle. Les durées des cycles adjacents seront automatiquement ajustées.</string>
     <string name="cycle_edit_confirm">Enregistrer la date</string>
     <string name="cycle_edit_collision_error">Un autre cycle commence déjà à cette date.</string>
@@ -502,7 +447,7 @@
     <string name="cycle_delete_body">La date de début de ce cycle sera supprimée. Les observations de la journée restent conservées dans le journal.</string>
     <string name="cycle_delete_confirm">Supprimer</string>
     <string name="cycle_start_badge">Début de cycle</string>
-    <!-- Data Portability and Local Wipe -->
+    
     <string name="settings_data_management_title">Gestion et sauvegarde des données</string>
     <string name="settings_export_title">Exporter mes données (JSON)</string>
     <string name="settings_export_body">Créez une archive complète et lisible de vos cycles, observations quotidiennes et préférences, directement sur votre appareil.</string>
@@ -541,7 +486,7 @@
     <string name="settings_import_strategy_replace">Remplacer toutes les données</string>
     <string name="settings_import_strategy_replace_desc">Efface les données locales actuelles avant d’importer la sauvegarde.</string>
     <string name="settings_import_dialog_confirm">Restaurer</string>
-    <!-- App Lock and Security -->
+    
     <string name="lock_screen_title">Luteal est verrouillé</string>
     <string name="lock_enter_pin">Saisissez votre code PIN pour déverrouiller l’application.</string>
     <string name="lock_submit_pin">Déverrouiller</string>
@@ -583,7 +528,7 @@
     <string name="dialog_disable_lock_body">Saisissez votre code PIN actuel pour désactiver le verrouillage.</string>
     <string name="dialog_disable_lock_error">Code PIN incorrect.</string>
     <string name="dialog_disable_lock_action">Désactiver</string>
-    <!-- Longitudinal Cycle History and Exclusion -->
+    
     <string name="journal_view_variability">Variabilité</string>
     <string name="variability_title">Historique et variabilité</string>
     <string name="variability_subtitle">Visualisation longitudinale de la durée de vos cycles</string>
@@ -611,7 +556,7 @@
     <string name="cycle_exclusion_reason_contraception_change">Changement contraceptif / Urgence</string>
     <string name="cycle_exclusion_reason_stress_or_travel">Stress intense / Déplacement</string>
     <string name="cycle_exclusion_reason_other">Autre motif</string>
-    <!-- Clinical Consultation Report -->
+    
     <string name="report_dialog_title">Rapport pour consultation médicale</string>
     <string name="report_dialog_subtitle">Synthétisez vos cycles, douleurs et symptômes dans un document médical imprimable.</string>
     <string name="report_preset_label">Période à inclure</string>
@@ -633,7 +578,7 @@
     <string name="settings_report_action">Générer un rapport de consultation</string>
     <string name="settings_report_success">Rapport médical exporté avec succès.</string>
     <string name="settings_report_error">Échec de la génération du rapport.</string>
-    <!-- Privacy-Safe Local Notifications -->
+    
     <string name="notif_channel_daily_title">Suivi quotidien</string>
     <string name="notif_channel_daily_desc">Rappels quotidiens pour enregistrer vos observations</string>
     <string name="notif_channel_window_title">Fenêtre estimée des règles</string>
@@ -673,7 +618,6 @@
     <string name="settings_notif_visibility_custom_desc">Définissez votre propre titre et message.</string>
     <string name="settings_notif_custom_title_label">Titre personnalisé</string>
     <string name="settings_notif_custom_body_label">Message personnalisé</string>
-    <string name="settings_notif_permission_denied">Permission de notification désactivée dans les paramètres système.</string>
     <string name="cycle_exclusion_save">Enregistrer</string>
 
     <string name="editor_biomarkers_show">Afficher les biomarqueurs</string>
@@ -728,7 +672,6 @@
     <string name="journal_patterns_most_frequent_phase">Majoritairement observé en phase %1$s (%2$d)</string>
     <string name="thermal_chart_title">Graphique thermique</string>
     <string name="thermal_chart_subtitle">Températures enregistrées pour le cycle en cours. Un décalage confirmé est rétrospectif, pas une prédiction de fertilité.</string>
-    <string name="thermal_chart_cd">Graphique de température basale pour le cycle en cours</string>
     <string name="thermal_chart_summary">Graphique thermique : %1$d relevés, %2$d perturbés, %3$s</string>
     <string name="thermal_chart_no_shift">aucun décalage thermique confirmé</string>
     <string name="variability_bar_cd">Cycle commencé le %1$s, durée %2$d jours, %3$d jours de saignements.</string>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,19 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <!-- Mirrors DarkColorScheme.background in Color.kt. -->
+    
     <color name="luteal_window_background">#121714</color>
     <color name="luteal_splash_background">#121714</color>
-    <!--
-      Evergreen80, not Evergreen40. The dark-theme accent is the only one of
-      the two that carries against a near-black splash; the light-theme
-      evergreen would all but disappear.
-    -->
+    
     <color name="luteal_splash_mark">#8FD4BE</color>
 
     <color name="widget_surface">#181E1B</color>
     <color name="widget_text_primary">#E4EAE5</color>
     <color name="widget_text_supporting">#C2C9C4</color>
     <color name="widget_accent">#8FD4BE</color>
-    <color name="widget_estimate">#E0BFA5</color>
     <color name="widget_outline">#3D4540</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,21 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <!--
-      Cold-start colours. These must track the Compose theme in
-      core/designsystem/theme/Color.kt: the window and splash background are
-      what the user sees before the first frame, so a mismatch reads as a
-      flash. Night values live in values-night/colors.xml.
-    -->
+    
     <color name="luteal_window_background">#F1EDE1</color>
     <color name="luteal_splash_background">#F1EDE1</color>
-    <!-- Evergreen40. Legible on the linen splash background. -->
+    
     <color name="luteal_splash_mark">#235B4E</color>
 
-    <!-- Resource-backed Glance palette, kept in step with Color.kt. -->
+    
     <color name="widget_surface">#FCFAF5</color>
     <color name="widget_text_primary">#252B27</color>
     <color name="widget_text_supporting">#555D58</color>
     <color name="widget_accent">#235B4E</color>
-    <color name="widget_estimate">#755B45</color>
     <color name="widget_outline">#D6D2C8</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-    English translation. French lives in the default `values/` folder, so any
-    locale without a translation of its own falls back to French. Keep this
-    file in step with `values/strings.xml`: every name must exist in both, and
-    format specifiers must match exactly (StringFormatSpecifierTest checks the
-    specifiers in every values*/ folder).
--->
+<?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="app_name">Luteal</string>
 
@@ -69,16 +62,10 @@
     <string name="nav_settings">Settings</string>
 
     <string name="today_title">Today</string>
-    <string name="today_greeting">Your tracking, made simple</string>
     <string name="cycle_day">Day %1$d of your cycle</string>
     <string name="cycle_day_caption">Cycle day</string>
-    <string name="cycle_started_on">Cycle started on %1$s</string>
     <string name="cycle_no_history_title">Start whenever you like</string>
     <string name="cycle_no_history_body">Record the first day of your period to begin your history. You can then fill it in day by day.</string>
-    <string name="action_start_period">Record the start of your period</string>
-    <string name="today_entry_title">Today’s observations</string>
-    <string name="today_entry_empty">No observations recorded today.</string>
-    <string name="today_entry_complete">Your observations are saved on this device.</string>
     <string name="action_log_today">Log today</string>
     <string name="action_edit_today">Edit observations</string>
     <string name="estimate_title">Next period</string>
@@ -87,7 +74,6 @@
         <item quantity="one">Range estimated from %1$d recorded cycle interval.</item>
         <item quantity="other">Range estimated from %1$d recorded cycle intervals.</item>
     </plurals>
-    <string name="estimate_unavailable">An estimated range will appear once you have recorded at least two cycle starts.</string>
     <string name="estimate_disclaimer">This estimate is based only on your recorded history and may change.</string>
     <string name="estimate_window_a11y">Estimated window of %1$d days</string>
     <string name="recorded_label">Recorded</string>
@@ -150,18 +136,10 @@
     <string name="journal_empty_title">Your journal is still empty</string>
     <string name="journal_empty_body">Add a first observation to start building your personal history.</string>
     <string name="journal_today">Today</string>
-    <plurals name="journal_observation_count">
-        <item quantity="one">%1$d observation</item>
-        <item quantity="other">%1$d observations</item>
-    </plurals>
     <string name="journal_no_observation">No observations</string>
     <string name="action_add_observation">Add an observation</string>
     <string name="journal_choose_date">Choose a date</string>
     <string name="journal_open_date">Open this date</string>
-    <string name="journal_summary_bleeding">Bleeding</string>
-    <string name="journal_summary_pain">Pain %1$d/5</string>
-    <string name="journal_summary_mood">Mood %1$d/5</string>
-    <string name="journal_summary_energy">Energy %1$d/5</string>
     <plurals name="journal_summary_other_count">
         <item quantity="one">%1$d other observation</item>
         <item quantity="other">%1$d other observations</item>
@@ -187,7 +165,6 @@
     <string name="editor_pain">Pain</string>
     <string name="editor_mood">Mood</string>
     <string name="editor_energy">Energy</string>
-    <string name="editor_scale_hint">1 means low, 5 means high.</string>
     <string name="editor_pain_scale_support">1: none, 5: very strong</string>
     <string name="editor_mood_scale_support">1: very difficult, 5: very good</string>
     <string name="editor_energy_scale_support">1: very low, 5: very high</string>
@@ -229,11 +206,8 @@
     <string name="editor_discard_body">The changes you entered for this date will be lost.</string>
     <string name="editor_discard_confirm">Leave without saving</string>
     <string name="editor_keep_editing">Keep editing</string>
-    <string name="action_retry">Try again</string>
-
     <string name="duo_title">Duo</string>
     <string name="duo_subtitle">Decide what you want to share, before any connection is made.</string>
-    <string name="duo_local_status">Local setup</string>
     <string name="duo_not_connected_title">No partner connected</string>
     <string name="duo_not_connected_body">Create an invitation or enter your partner’s code to set up a link. You then choose what you share, category by category, and you can revoke it at any time.</string>
     <string name="duo_sharing_title">What you allow</string>
@@ -253,14 +227,6 @@
     <string name="duo_share_support_desc">Allow sharing of requests you make yourself.</string>
     <string name="duo_preview_title">Partner preview</string>
     <string name="duo_preview_body">This preview shows only the categories you allowed. No data is sent.</string>
-    <string name="duo_preview_hidden">No tracking data is visible with the current permissions.</string>
-    <string name="duo_preview_cycle_day">Shared cycle day: %1$d</string>
-    <string name="duo_preview_no_cycle">No cycle day to share</string>
-    <string name="duo_preview_estimate">Shared range: %1$s to %2$s</string>
-    <string name="duo_preview_mood">Shared mood: %1$d out of 5</string>
-    <string name="duo_preview_energy">Shared energy: %1$d out of 5</string>
-    <string name="duo_preview_support_ready">Support requests you make</string>
-    <string name="duo_preview_local_label">Local preview</string>
     <string name="duo_error_invalid_pairing_link">Incomplete sharing link: use the full link provided by your partner.</string>
     <string name="duo_private_notes_never_shared">Private notes are never included in Duo sharing.</string>
 
@@ -273,13 +239,11 @@
     <string name="settings_backup_body">Luteal’s sensitive data is not included in the Android cloud backup.</string>
     <string name="settings_sync_title">Sync</string>
     <string name="settings_sync_body">Turn on sync to find your data across your devices. Your observations stay saved on this device; sync runs in the background and never blocks the app. No connection is made unless you turn it on.</string>
-    <string name="settings_sync_trial_body">Connect this device to a local folicular server to try cycle sync. Your data stays saved on this device; sync runs in the background and never blocks the app. No connection is made unless you turn it on.</string>
     <string name="sync_transport_notice">Your observations are end-to-end encrypted on this device before anything is sent: the server only ever holds data it cannot read. It does still see when you sync and how many records you have. Your account code is the only key: without it nobody can decrypt your data, including us.</string>
     <string name="settings_sync_online_title">Online mode</string>
     <string name="settings_sync_online_body">Turns on sync with the Luteal server. Off by default.</string>
     <string name="settings_sync_server_body">By default, sync connects to the official Luteal server. You can also enter the address of your own self-hosted folicular instance.</string>
     <string name="settings_sync_base_url_label">Server address</string>
-    <string name="settings_sync_base_url_default">http://10.0.2.2:8080</string>
     <string name="settings_sync_save">Save</string>
     <string name="settings_sync_now">Sync now</string>
     <string name="settings_sync_in_progress">Syncing…</string>
@@ -296,10 +260,9 @@
     <string name="settings_recovery_action">Restore this account</string>
     <string name="settings_recovery_in_progress">Restoring…</string>
     <string name="settings_recovery_success">Account restored. Sync will now retrieve your history.</string>
-    <string name="settings_recovery_error_already_linked">This device is already linked to an account. Erase local data before restoring another account.</string>
     <string name="settings_recovery_error_failed">Account restoration failed. Check your account code and connection.</string>
     <string name="settings_sync_last_success">Last sync: %1$s</string>
-    <string name="sync_error_auth_rejected">The server no longer accepts this device. Reconnect your account from Settings > Synchronisation using your account code.</string>
+    <string name="sync_error_auth_rejected">The server no longer accepts this device. Reconnect your account from Settings &gt; Synchronisation using your account code.</string>
     <string name="settings_sync_last_error">Sync failed: %1$s</string>
     <string name="settings_appearance_title">Appearance</string>
     <string name="settings_appearance_body">The light or dark theme follows your device setting.</string>
@@ -319,15 +282,8 @@
 
     <string name="backfill_title">Add a past cycle</string>
     <string name="backfill_body">Enter the start dates of your recent cycles to get estimates sooner. You can add up to 3 months of history.</string>
-    <string name="backfill_date_label">Period start date</string>
     <string name="backfill_confirm">Add this cycle</string>
     <string name="backfill_action">Add a past cycle</string>
-    <string name="backfill_already_exists">A cycle already exists on that date.</string>
-
-
-    <string name="content_description_previous_day">Previous day</string>
-    <string name="content_description_next_day">Next day</string>
-    <string name="content_description_selected_tab">Selected section: %1$s</string>
     <string name="onboarding_title">Welcome to Luteal</string>
     <string name="onboarding_subtitle">Private, offline cycle tracking that respects your data.</string>
     <string name="onboarding_welcome_step_title">Your data stays on this device</string>
@@ -397,12 +353,7 @@
     <string name="onboarding_button_back">Back</string>
     <string name="onboarding_button_start">Get started</string>
     <string name="onboarding_button_skip">Skip the introduction</string>
-    <string name="action_start_period_today">Record my period today</string>
-    <string name="action_start_period_today_desc">Starts a new cycle dated today.</string>
-    <string name="action_log_daily_entry">Log the day</string>
-    <string name="action_edit_daily_entry">Edit today’s notes</string>
     <string name="today_summary_title">Today’s observations</string>
-    <string name="today_summary_empty_title">No observations recorded</string>
     <string name="today_summary_empty_body">Take a moment to note your flow, how you feel, or your energy level.</string>
     <string name="today_bleeding_label">Flow: %1$s</string>
     <string name="today_pain_label">Pain: %1$d/5</string>
@@ -419,9 +370,6 @@
     </plurals>
     <string name="estimate_in_progress">Estimated period range under way</string>
     <string name="action_start_period_short">Period start</string>
-    <string name="action_log_entry_short">Log the day</string>
-    <string name="today_summary_empty_short">No observations entered</string>
-    <string name="today_summary_open_hint">Open to add an observation</string>
     <string name="estimate_unavailable_short">Waiting for history (2 cycles)</string>
     <string name="estimate_unavailable_hint">Record your cycles as they come, or add your recent past cycles, to get an estimate.</string>
     <string name="estimate_out_of_range_short">No estimate available for your cycles</string>
@@ -430,7 +378,6 @@
         <item quantity="one">Range passed %1$d day ago</item>
         <item quantity="other">Range passed %1$d days ago</item>
     </plurals>
-    <string name="cycle_no_history_short">No cycle under way</string>
     <string name="crash_dialog_title">Luteal ran into a problem</string>
     <string name="crash_dialog_text">The app stopped unexpectedly. You can send an anonymous report to help us fix it. No tracking data is included.</string>
     <string name="crash_dialog_comment">Describe what you were doing (optional)</string>
@@ -475,9 +422,7 @@
     <string name="duo_support_kind_space">Space</string>
     <string name="duo_refresh">Refresh</string>
 
-    <!-- Calendar Screen & Grid -->
-    <string name="calendar_title">Calendar</string>
-    <string name="calendar_subtitle">Monthly view of your cycles and observations</string>
+    
     <string name="calendar_view_calendar">Calendar</string>
     <string name="calendar_view_list">Timeline</string>
     <string name="calendar_previous_month">Previous month</string>
@@ -488,15 +433,9 @@
     <string name="calendar_legend_estimated_period">Estimated window</string>
     <string name="calendar_legend_observation">Observations (pain, mood, etc.)</string>
     <string name="calendar_day_cd_recorded">%1$s, period (%2$s)</string>
-    <string name="calendar_day_cd_estimated">%1$s, estimated period window</string>
-    <string name="calendar_day_cd_observations">%1$s, %2$d observation(s)</string>
     <string name="calendar_day_empty_inspection">No observations recorded for this day.</string>
-    <string name="calendar_day_inspection_title">Day details</string>
-
-    <!-- Cycle Management -->
     <string name="cycle_action_edit">Edit cycle start</string>
     <string name="cycle_action_delete">Delete cycle</string>
-    <string name="cycle_edit_title">Edit start date</string>
     <string name="cycle_edit_body">Choose the start date for this cycle. Adjacent cycle lengths will be adjusted automatically.</string>
     <string name="cycle_edit_confirm">Save date</string>
     <string name="cycle_edit_collision_error">Another cycle already starts on this date.</string>
@@ -504,7 +443,7 @@
     <string name="cycle_delete_body">The start date of this cycle will be removed. Your daily observations for this date will be kept in the journal.</string>
     <string name="cycle_delete_confirm">Delete</string>
     <string name="cycle_start_badge">Cycle start</string>
-    <!-- Data Portability and Local Wipe -->
+    
     <string name="settings_data_management_title">Data management &amp; backup</string>
     <string name="settings_export_title">Export my data (JSON)</string>
     <string name="settings_export_body">Create a complete, readable backup of your cycles, daily observations, and preferences directly on your device.</string>
@@ -543,7 +482,7 @@
     <string name="settings_import_strategy_replace">Replace all data</string>
     <string name="settings_import_strategy_replace_desc">Erases all current local data before restoring the backup.</string>
     <string name="settings_import_dialog_confirm">Restore</string>
-    <!-- App Lock and Security -->
+    
     <string name="lock_screen_title">Luteal is locked</string>
     <string name="lock_enter_pin">Enter your PIN to unlock the application.</string>
     <string name="lock_submit_pin">Unlock</string>
@@ -585,7 +524,7 @@
     <string name="dialog_disable_lock_body">Enter your current PIN to disable app lock.</string>
     <string name="dialog_disable_lock_error">Incorrect PIN.</string>
     <string name="dialog_disable_lock_action">Disable</string>
-    <!-- Longitudinal Cycle History and Exclusion -->
+    
     <string name="journal_view_variability">Variability</string>
     <string name="variability_title">Cycle history &amp; variability</string>
     <string name="variability_subtitle">Longitudinal view of your cycle lengths</string>
@@ -613,7 +552,7 @@
     <string name="cycle_exclusion_reason_contraception_change">Contraceptive change / Emergency</string>
     <string name="cycle_exclusion_reason_stress_or_travel">Severe stress / Travel</string>
     <string name="cycle_exclusion_reason_other">Other reason</string>
-    <!-- Clinical Consultation Report -->
+    
     <string name="report_dialog_title">Medical consultation report</string>
     <string name="report_dialog_subtitle">Synthesize your cycles, pain, and symptoms into a printable medical document.</string>
     <string name="report_preset_label">Period to include</string>
@@ -635,7 +574,7 @@
     <string name="settings_report_action">Generate consultation report</string>
     <string name="settings_report_success">Medical report exported successfully.</string>
     <string name="settings_report_error">Report generation failed.</string>
-    <!-- Privacy-Safe Local Notifications -->
+    
     <string name="notif_channel_daily_title">Daily tracking</string>
     <string name="notif_channel_daily_desc">Daily reminders to record your observations</string>
     <string name="notif_channel_window_title">Estimated period window</string>
@@ -675,7 +614,6 @@
     <string name="settings_notif_visibility_custom_desc">Define your own title and message.</string>
     <string name="settings_notif_custom_title_label">Custom title</string>
     <string name="settings_notif_custom_body_label">Custom message</string>
-    <string name="settings_notif_permission_denied">Notification permission disabled in system settings.</string>
     <string name="cycle_exclusion_save">Save</string>
 
     <string name="editor_biomarkers_show">Show biomarkers</string>
@@ -730,7 +668,6 @@
     <string name="journal_patterns_most_frequent_phase">Most reported in %1$s phase (%2$d)</string>
     <string name="thermal_chart_title">Thermal chart</string>
     <string name="thermal_chart_subtitle">Recorded temperatures for the current cycle. A confirmed shift is retrospective, not a fertility prediction.</string>
-    <string name="thermal_chart_cd">Basal temperature chart for the current cycle</string>
     <string name="thermal_chart_summary">Thermal chart: %1$d temperature readings, %2$d disturbed, %3$s</string>
     <string name="thermal_chart_no_shift">no confirmed thermal shift</string>
     <string name="variability_bar_cd">Cycle starting %1$s, length %2$d days, %3$d bleeding days.</string>

--- a/app/src/test/java/fr/luteal/core/data/local/RoomSchemaHarnessTest.kt
+++ b/app/src/test/java/fr/luteal/core/data/local/RoomSchemaHarnessTest.kt
@@ -28,18 +28,91 @@ class RoomSchemaHarnessTest {
 
     @Test
     fun latestSchemaCreatesAndValidates() {
-        // Creating at version 7 validates the freshly created file against the
-        // exported 7.json: any entity/annotation drift fails here.
-        helper.createDatabase(TEST_DB, 7).use { db ->
+        helper.createDatabase(TEST_DB, 8).use { db ->
             db.query("SELECT count(*) FROM sqlite_master WHERE type='table'").use { cursor ->
                 assertTrue(cursor.moveToFirst())
                 assertTrue(cursor.getInt(0) > 0)
             }
         }
+        helper.runMigrationsAndValidate(TEST_DB, 8, true).close()
+    }
 
-        // Re-opening validates the on-disk file again through the full
-        // configuration path (tables, indices, foreign keys).
-        helper.runMigrationsAndValidate(TEST_DB, 7, true).close()
+    @Test
+    fun migrate1To2() {
+        helper.createDatabase(TEST_DB, 1).close()
+        helper.runMigrationsAndValidate(TEST_DB, 2, true, LutealDatabase.MIGRATION_1_2).close()
+    }
+
+    @Test
+    fun migrate2To3() {
+        helper.createDatabase(TEST_DB, 2).close()
+        helper.runMigrationsAndValidate(TEST_DB, 3, true, LutealDatabase.MIGRATION_2_3).close()
+    }
+
+    @Test
+    fun migrate3To4() {
+        helper.createDatabase(TEST_DB, 3).use { db ->
+            db.execSQL(
+                "INSERT INTO cycle_sync_state (cycleId, clientRev, createdAtEpochMillis, updatedAtEpochMillis, dirty) " +
+                    "VALUES ('c1', 'rev1', 1000, 2000, 1)"
+            )
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 4, true, LutealDatabase.MIGRATION_3_4).use { db ->
+            db.query("SELECT * FROM sync_state WHERE entityId = 'c1'").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+            }
+        }
+    }
+
+    @Test
+    fun migrate4To5() {
+        helper.createDatabase(TEST_DB, 4).close()
+        helper.runMigrationsAndValidate(TEST_DB, 5, true, LutealDatabase.MIGRATION_4_5).close()
+    }
+
+    @Test
+    fun migrate5To6() {
+        helper.createDatabase(TEST_DB, 5).use { db ->
+            db.execSQL(
+                "INSERT INTO cycles (id, startDate, periodDaysJson, averageLengthDays, lutealPhaseLengthDays, isSynced) " +
+                    "VALUES ('c1', '2026-08-01', '[]', 28, 14, 0)"
+            )
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 6, true, LutealDatabase.MIGRATION_5_6).use { db ->
+            db.query("SELECT isExcludedFromEstimates, exclusionReason FROM cycles WHERE id = 'c1'").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                org.junit.Assert.assertEquals(0, cursor.getInt(0))
+            }
+        }
+    }
+
+    @Test
+    fun migrate6To7() {
+        helper.createDatabase(TEST_DB, 6).close()
+        helper.runMigrationsAndValidate(TEST_DB, 7, true, LutealDatabase.MIGRATION_6_7).close()
+    }
+
+    @Test
+    fun migrate7To8() {
+        helper.createDatabase(TEST_DB, 7).close()
+        helper.runMigrationsAndValidate(TEST_DB, 8, true, LutealDatabase.MIGRATION_7_8).close()
+    }
+
+    @Test
+    fun migrateAll_1To8() {
+        helper.createDatabase(TEST_DB, 1).close()
+        helper.runMigrationsAndValidate(
+            TEST_DB,
+            8,
+            true,
+            LutealDatabase.MIGRATION_1_2,
+            LutealDatabase.MIGRATION_2_3,
+            LutealDatabase.MIGRATION_3_4,
+            LutealDatabase.MIGRATION_4_5,
+            LutealDatabase.MIGRATION_5_6,
+            LutealDatabase.MIGRATION_6_7,
+            LutealDatabase.MIGRATION_7_8
+        ).close()
     }
 
     companion object {

--- a/app/src/test/java/fr/luteal/core/network/SyncWireTest.kt
+++ b/app/src/test/java/fr/luteal/core/network/SyncWireTest.kt
@@ -167,4 +167,29 @@ class SyncWireTest {
         assertEquals(true, tombstone.deleted)
         assertNull(tombstone.openPayload(sealer))
     }
+
+    @Test
+    fun `pull result gracefully skips unknown entity type from newer backend`() {
+        val json = """
+            {
+              "changes": [
+                {
+                  "seq": 10,
+                  "entity_type": "future_unknown_entity_type",
+                  "entity_id": "019832e0-6c14-7000-8000-000000000001",
+                  "client_rev": "019832e0-6c14-7000-8000-000000000002",
+                  "deleted": false,
+                  "updated_at": "2026-07-01T08:00:00Z"
+                }
+              ],
+              "cursor": 500,
+              "has_more": false
+            }
+        """.trimIndent()
+
+        val result = json.toPullResultWire()
+        assertEquals(1, result.changes.size)
+        assertNull(result.changes[0].entityType)
+        assertNull(result.changes[0].openPayload(sealer))
+    }
 }


### PR DESCRIPTION
Addresses findings identified during comprehensive codebase review:

- **Lint Compliance:** Guarded notification dispatch with `POST_NOTIFICATIONS` permission check on Android 13+ (`NotificationAlarmReceiver`), pre-resolved string resources in Compose dialogs to prevent configuration-sensitivity lint errors (`SettingsScreen`, `AppLockScreen`, `DuoScreen`), and adjusted modifier parameter positioning (`CycleVariabilityVisualizer`).
- **Database Indices & Schema v8:** Added database indices on `symptom_logs(date)`, `sync_state(dirty, entityType)`, and `cycles(startDate, endDate)`. Bumped database to version 8 with `MIGRATION_7_8`. Reconstructed historical schemas 1–6 and expanded `RoomSchemaHarnessTest` with migration coverage from version 1 through 8.
- **Sync Engine Atomicity:** Wrapped `CycleSyncEngine.applyPage` batch commits in `database.withTransaction` to ensure atomic commits and avoid intermediate Room flow updates.
- **Contract Forward-Compatibility:** Added `SafeEntityTypeSerializer` to gracefully handle unknown entity types from newer backend contracts without failing sync pulls.
- **Privacy & Reports:** Hardened ACRA configuration in `LutealApp` to exclude `SHARED_PREFERENCES` from crash dumps. Refactored `PdfReportBuilder` with dynamic page breaks and removed hardcoded record truncation. Added error propagation in `LutealViewModel.exportClinicalReport`.
- **Resource Cleanup:** Pruned 48 orphaned string, color, and plural resources while preserving exact parity between English and French resource files.